### PR TITLE
Proof-of-concept for testing shell sessions

### DIFF
--- a/convert_shell_session_to_pexpect_test.py
+++ b/convert_shell_session_to_pexpect_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+
+# Debug tips:
+# to debug commands, you can use shell.interact() to drop into the shell
+# and see what is going on
+
+import sys
+from dataclasses import dataclass
+from dataclasses import field
+import pexpect
+import re
+import typing as t
+import os
+
+# Either, or:
+#   $
+#   [nix-shell:/some/path]$
+prompt = re.compile("^  (\[nix-shell:.*\])?\$ ")
+
+
+@dataclass
+class Block:
+    """Shell sessions are constructed of blocks. Each block has a
+    line of command followed by one or more lines of output."""
+
+    command: t.Optional[str] = None
+    output: t.List[str] = field(default_factory=lambda: [])
+    debug: bool = False
+
+
+blocks = []
+new_block = Block()
+
+filename = sys.argv[1]
+with open(filename, "r") as file:
+
+    for line in file.readlines():
+        if prompt.match(line):
+            new_block.command = re.sub(prompt, "", line).strip()
+        elif line.startswith("  "):
+            new_block.output.append(line.strip())
+        else:
+            blocks.append(new_block)
+            new_block = Block()
+    blocks.append(new_block)
+
+shell = pexpect.spawn("nix-shell shell-darwin.nix")
+dir_ = os.path.dirname(filename)
+shell.sendline(f"cd {dir_}")
+for block in blocks:
+    shell.sendline(block.command)
+    if "DEBUG" in block.output:
+        shell.interact()
+
+    shell.expect("\n".join(block.output).replace("...", ".*"))

--- a/convert_shell_session_to_pexpect_test.py
+++ b/convert_shell_session_to_pexpect_test.py
@@ -9,6 +9,7 @@ import sys
 from dataclasses import dataclass
 from dataclasses import field
 import pexpect
+import platform
 import re
 import typing as t
 import os
@@ -45,7 +46,11 @@ with open(filename, "r") as file:
             new_block = Block()
     blocks.append(new_block)
 
-shell = pexpect.spawn("nix-shell shell-darwin.nix")
+if platform.system() == "Darwin":
+    shell = pexpect.spawn("nix-shell shell-darwin.nix")
+else:
+    shell = pexpect.spawn("nix-shell")
+
 dir_ = os.path.dirname(filename)
 shell.sendline(f"cd {dir_}")
 for block in blocks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -280,6 +280,17 @@ optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [[package]]
+name = "pexpect"
+version = "4.8.0"
+description = "Pexpect allows easy control of interactive console applications."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+ptyprocess = ">=0.5"
+
+[[package]]
 name = "platformdirs"
 version = "2.5.2"
 description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
@@ -290,6 +301,14 @@ python-versions = ">=3.7"
 [package.extras]
 docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
 test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+description = "Run a subprocess in a pseudo terminal"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pydata-sphinx-theme"
@@ -587,7 +606,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "b3bf02fb433540323d66abcc309de7ccac0855dd1f3bf7e25bea65de674f0e3b"
+content-hash = "52b98e5c703a8cc49742791b71f612ce32af135f612e7084d6f54202f071e1a0"
 
 [metadata.files]
 alabaster = [
@@ -740,9 +759,17 @@ pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
     {file = "pathspec-0.9.0.tar.gz", hash = "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"},
 ]
+pexpect = [
+    {file = "pexpect-4.8.0-py2.py3-none-any.whl", hash = "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937"},
+    {file = "pexpect-4.8.0.tar.gz", hash = "sha256:fc65a43959d153d0114afe13997d439c22823a27cefceb5ff35c2178c6784c0c"},
+]
 platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+ptyprocess = [
+    {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
+    {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
 ]
 pydata-sphinx-theme = [
     {file = "pydata-sphinx-theme-0.7.2.tar.gz", hash = "sha256:671df35fcdd290eafbd23d0595e6d359dbe90b2e64e6c3f4dc88276eed4a065e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.9"
 
 livereload = "*"
 myst-parser = {version = "*", extras = ["linkify"]}
+pexpect = "*"
 sphinx = "*"
 sphinx-book-theme = "^0.2.0"
 sphinx-copybutton = "*"

--- a/run_code_block_tests.sh
+++ b/run_code_block_tests.sh
@@ -1,1 +1,4 @@
-find extracted -name "test_*" -exec echo "running {}" \; -execdir {} \;
+set -euo pipefail
+
+find extracted -name "*.shell_session" -exec echo "running {}" \; -exec ./convert_shell_session_to_pexpect_test.py {} \;
+find extracted -name "test_*"  -exec echo "running {}" \; -execdir {} \;

--- a/run_code_block_tests.sh
+++ b/run_code_block_tests.sh
@@ -1,4 +1,4 @@
 set -euo pipefail
 
-find extracted -name "*.shell_session" -exec echo "running {}" \; -exec ./convert_shell_session_to_pexpect_test.py {} \;
-find extracted -name "test_*"  -exec echo "running {}" \; -execdir {} \;
+find extracted -name "*.shell_session" | xargs -I{} sh -c 'echo "running {}"; ./convert_shell_session_to_pexpect_test.py {};'
+find extracted -name "test_*" | xargs -I{} sh -c 'echo "running {}"; cd `dirname {}`; ./`basename {}`'

--- a/run_code_block_tests.sh
+++ b/run_code_block_tests.sh
@@ -1,4 +1,4 @@
 set -euo pipefail
 
-find extracted -name "*.shell_session" | xargs -I{} sh -c 'echo "running {}"; ./convert_shell_session_to_pexpect_test.py {};'
-find extracted -name "test_*" | xargs -I{} sh -c 'echo "running {}"; cd `dirname {}`; ./`basename {}`'
+find extracted -name "*.shell_session" -print0 | xargs -0 -I{} sh -c 'echo "running {}"; ./convert_shell_session_to_pexpect_test.py {};'
+find extracted -name "test_*" -print0 | xargs -0 -I{} sh -c 'echo "running {}"; cd `dirname {}`; ./`basename {}`'

--- a/source/_ext/extractable_code_block.py
+++ b/source/_ext/extractable_code_block.py
@@ -63,8 +63,8 @@ class ExtractableCodeBlock(CodeBlock):
         with open(path, "w") as f:
             f.write(self.block_text)
 
-        # make bash scripts executable
-        if path.endswith(".sh"):
+        # make scripts executable
+        if path.endswith(".sh") or path.endswith(".py"):
             st = os.stat(path)
             os.chmod(path, st.st_mode | stat.S_IEXEC)
 

--- a/source/tutorials/ad-hoc-developer-environments.md
+++ b/source/tutorials/ad-hoc-developer-environments.md
@@ -13,20 +13,20 @@ A shell environment gives you access to the exact versions of packages specified
 
 A hello world example:
 
-```shell-session
-$ hello
-The program ‘hello’ is currently not installed.
+```{code-block} shell-session hello.shell_session
+  $ hello
+  hello not found
 
-$ nix-shell -p hello
+  $ nix-shell -p hello
 
-[nix-shell:~]$ hello
-Hello, world!
+  [nix-shell:~]$ hello
+  Hello, world!
 
-[nix-shell:~]$ exit
-exit
+  [nix-shell:~]$ exit
+  exit
 
-$ hello
-The program ‘hello’ is currently not installed.
+  $ hello
+  hello not found
 ```
 
 Here we used the `-p` (packages) flag to specify that we needed the `hello` dependency. Nix found it, downloaded it, and made it available in a shell environment.
@@ -49,10 +49,11 @@ Anything that's in the [official package list](https://nixos.org/nixos/packages.
 
 You can search the package list using:
 
-```shell-session
-$ nix-env -qaP git
-gitAndTools.gitFull  git-2.25.0
-gitMinimal           git-2.25.0
+```{code-block} shell-session nix_env.shell_session
+  $ nix-env -qaP git
+  nixpkgs.git      git-2.3...
+  nixpkgs.git-doc  git-2.3...
+  nixpkgs.gitFull  git-2.3...
 ```
 
 The first column is the {term}`attribute name` and the second is the {term}`package name` and its version.
@@ -67,19 +68,15 @@ The query you use for searching packages is a regex, so be aware when it comes t
 
 Once you have the {term}`attribute name` for packages, you can start a shell:
 
-```shell-session
-$ nix-shell -p gitMinimal vim nano joe
-these paths will be fetched (44.16 MiB download, 236.37 MiB unpacked):
-...
-/nix/store/fsn35pc8njnimgn2sn26dlsyxya1wssb-vim-8.2.0013
-/nix/store/wdqjszpr5dlys53d79fym6rv9vyyz29h-joe-4.6
-/nix/store/hx63qkip16i4wifaqgxwrrmxj4az53h1-git-2.25.0
+```{code-block} shell-session ad_hoc.shell_session
+  $ nix-shell -p gitMinimal vim nano joe
+  ...
 
-[nix-shell:~]$ git --version
-git version 2.25.0
+  [nix-shell:~]$ git --version
+  git version 2.3...
 
-[nix-shell:~]$ which git
-/nix/store/hx63qkip16i4wifaqgxwrrmxj4az53h1-git-2.25.0/bin/git
+  [nix-shell:~]$ which git
+  /nix/store/...-git-2.3.../bin/git
 ```
 
 Note that even if you had Git installed before, in the shell, only the exact version installed by Nix is used.
@@ -92,12 +89,12 @@ Press `CTRL-D` to exit the shell and those packages won't be available anymore.
 
 Let's try a quick example using Python and `$PYTHONPATH`:
 
-```shell-session
-$ nix-shell -p 'python38.withPackages (packages: [ packages.django ])'
-...
+```{code-block} shell-session django.shell_session
+  $ nix-shell -p 'python38.withPackages (packages: [ packages.django ])'
+  ...
 
-[nix-shell:~]$ python -c 'import django; print(django)'
-<module 'django' from '/nix/store/c8ipxqsgh8xd6zmwb026lldsgr7hi315-python3-3.8.1-env/lib/python3.8/site-packages/django/__init__.py'>
+  [nix-shell:~]$ python -c 'import django; print(django)'
+  <module 'django' from '/nix/store/...-python3-3.8...-env/lib/python3.8/site-packages/django/__init__.py'>
 ```
 
 We create an ad hoc environment with `$PYTHONPATH` set and `python` available, along with the `django` package.
@@ -116,23 +113,24 @@ Nix also offers fully reproducible environments, which it calls pure environment
 
 The following is a fully reproducible example and something that different colleagues with different machines, for example, could share.
 
-```shell-session
-$ nix-shell --pure -p git -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/2a601aafdc5605a5133a2ca506a34a3a73377247.tar.gz
+```{code-block} shell-session pure.shell_session
+  $ nix-shell --pure -p git -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/2a601aafdc5605a5133a2ca506a34a3a73377247.tar.gz
 
-[nix-shell:~]$ git --version
-git version 2.25.4
+  [nix-shell:~]$ git --version
+  git version 2.33.1
 ```
 
 There are two things going on here:
 
 1. The `--pure` flag makes sure that the bash environment from your system is not inherited. That means only the `git` that Nix installed is available inside the shell. This is useful for one-liners and scripts that run, for example, within a CI environment. While developing, however, we'd like to have our editor around and a bunch of other things. Therefore we might skip the flag for development environments but use it in build ones.
-2. The `-I` flag pins the Nixpkgs revision to an **exact Git revision**, leaving no doubt about which exact version of Nix packages will be used.
+2. The `-I` flag pins the Nixpkgs revision to an **exact git revision**, leaving no doubt which exact version of Nix packages will be used.
+3. Notice how we no longer use elipsis (`...`) in the output example like we do in previous examples. This is because we know exactly which version of git will be present in this nix-shell, due to pinning the shell to a specific commit of nixpkgs.
 
 ## Reproducible executables
 
 Finally, we can wrap scripts with Nix to provide a reproducible shell environment that we can commit to a Git repository and share with strangers online. As long as they have Nix installed, they'll be able to execute the script without worrying about manually installing (and later uninstalling) dependencies at all.
 
-```python
+```{code-block} python test_django.py
 #! /usr/bin/env nix-shell
 #! nix-shell --pure -i python -p "python38.withPackages (ps: [ ps.django ])"
 #! nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/2a601aafdc5605a5133a2ca506a34a3a73377247.tar.gz
@@ -145,7 +143,7 @@ print(django)
 This is essentially the same example as in the previous section, but this time declaratively source controlled! All of the required Nix commands are included as `#!` shebang headers in the script itself.
 
 :::{note}
-The multiline shebang format is a feature of [nix-shell](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html#use-as-a--interpreter). 
+The multiline shebang format is a feature of [nix-shell](https://nixos.org/manual/nix/stable/command-ref/nix-shell.html#use-as-a--interpreter).
 All the subsequent `#! nix-shell` lines are used to build up the shell's configuration before building the shell and executing the body of the script.
 :::
 

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -4,8 +4,6 @@ Let's build a Python web application using the Flask web framework as an exercis
 
 Create a new file called `default.nix`. This file is conventionally used for specifying packages. Add the code:
 
-
-
 ```{code-block} nix default.nix
 { pkgs ? import <nixpkgs> {} }:
 
@@ -54,17 +52,25 @@ setup(
 
 Now build the package with:
 
-```{code-block} bash test_nix_build.sh
-nix-build
+```{code-block} shell-session nix_build.shell-session
+  $ nix-build
+  this derivation will be built:
+    /nix/store/...-myapp-0.1.drv
+  OK
+  Finished executing setuptoolsCheckPhase
+  /nix/store/...-myapp-0.1
 ```
 
-This will create a symbolic link `result` to our package's path in the Nix store, which looks like `/nix/store/6i4l781jwk5vbia8as32637207kgkllj-myapp-0.1`. Look around to see what's inside.
+This will create a symbolic link `result` to our package's path in the Nix store, which looks like `/nix/store/<HASH>-myapp-0.1`. Look around to see what's inside.
 
 You may notice we can run the application from the package like this: `./result/bin/myapp`. But we can also use the `default.nix` as a shell environment to get the same result:
 
-```bash
-nix-shell default.nix
-python myapp.py
+```{code-block} shell-session myapp.shell-session
+  $ nix-shell default.nix
+  ...
+
+  [nix-shell:]$ python myapp.py
+  Running on http://...:5000/
 ```
 
 In this context, Nix takes on the role that you would otherwise use pip or virtualenv for. Nix installs required dependencies and separates the environment from others on your system.


### PR DESCRIPTION
In https://github.com/nix-dot-dev/nix.dev/pull/248 I introduced a way to export code samples into files, and then test them.

This commit adds an additional improvement on top of that: to test shell session examples, command by command, and verify the output of commands matches the output given in the shell session example.