### PR TITLE
codify terminology

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,3 +183,36 @@ Collect links at the end of each section, which are delimited by headings.
 
 [Here is a discussion of different line wrapping styles.]: https://web.archive.org/web/20220519121408/https://mtsknn.fi/blog/4-1-wrapping-styles-for-markdown-prose-and-code-comments/
 [reference links]: https://github.github.com/gfm/#reference-link
+
+### Nomenclature
+
+To avoid confusion around all the things called Nix, always use the following terms with capitalization as given:
+
+- Nix ecosystem
+
+  All of the below.
+
+  - Nix package manager
+
+    Command line tool.
+
+  - Nix language
+
+      Programming langauge to declare packages and configurations for the Nix package manager.
+
+    - Nix expression
+
+      Expression written in Nix language.
+
+    - Nix file
+
+      File containing Nix expression, usally ends in `.nix`.
+
+  - Nix package collection (`nixpkgs`)
+
+    Read `nixpkgs` as "Nix packages".
+
+  - NixOS
+
+    Linux distribution based on Nix package manager and `nixpkgs`.
+    Read "Nix Oh Es".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,10 @@ Collect links at the end of each section, which are delimited by headings.
 
 ### Terminology
 
-To avoid confusion around all the things called Nix, always use the following terms with capitalization as given:
+To avoid confusion around all the things called Nix, always use the following terms with capitalization as given.
+
+Terms in brackets (`[  ]`) are optional.
+Terms in parentheses (`(  )`) are abbreviations.
 
 - Nix ecosystem
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ Terms in parentheses (`(  )`) are abbreviations.
 
   - Nix package manager
 
-    Command line tool.
+    - `nix` [command [line interface]] (Nix CLI)
 
   - Nix language
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Collect links at the end of each section, which are delimited by headings.
 [Here is a discussion of different line wrapping styles.]: https://web.archive.org/web/20220519121408/https://mtsknn.fi/blog/4-1-wrapping-styles-for-markdown-prose-and-code-comments/
 [reference links]: https://github.github.com/gfm/#reference-link
 
-### Nomenclature
+### Terminology
 
 To avoid confusion around all the things called Nix, always use the following terms with capitalization as given:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,7 +215,9 @@ Terms in parentheses (`(  )`) are abbreviations.
 
     Read `nixpkgs` as "Nix packages".
 
-  - NixOS
+  - NixOS [Linux distribution]
 
     Linux distribution based on Nix package manager and `nixpkgs`.
     Read /nɪks oʊ ɛs/ ("Nix Oh Es").
+
+    - NixOS module collection (NixOS modules)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,7 @@ To avoid confusion around all the things called Nix, always use the following te
 
   - Nix expression
 
-    Expression written in Nix language.
+    Expression written in the Nix language.
 
   - Nix file
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,36 +188,32 @@ Collect links at the end of each section, which are delimited by headings.
 
 To avoid confusion around all the things called Nix, always use the following terms with capitalization as given.
 
-Terms in brackets (`[  ]`) are optional.
-Terms in parentheses (`(  )`) are abbreviations.
+- Nix
 
-- Nix ecosystem
+  Build system and package manager.
 
-  All of the below.
+  Read /nɪks/ ("Niks").
 
-  - Nix package manager
+- Nix language
 
-    - `nix` [command [line interface]] (Nix CLI)
+    Programming language to declare packages and configurations for Nix.
 
-  - Nix language
+  - Nix expression
 
-      Programming language to declare packages and configurations for the Nix package manager.
+    Expression written in Nix language.
 
-    - Nix expression
+  - Nix file
 
-      Expression written in Nix language.
+    File (`.nix`) containing a Nix expression.
 
-    - Nix file
+- Nixpkgs
 
-      File containing Nix expression, usally ends in `.nix`.
+  Software distribution built with Nix.
 
-  - Nix package collection (`nixpkgs`)
+  Read /nɪks ˈpækɪʤɪz/ ("Niks packages").
 
-    Read `nixpkgs` as "Nix packages".
+- NixOS
 
-  - NixOS [Linux distribution]
+  Linux distribution based on Nix and Nixpkgs.
 
-    Linux distribution based on Nix package manager and `nixpkgs`.
-    Read /nɪks oʊ ɛs/ ("Nix Oh Es").
-
-    - NixOS module collection (NixOS modules)
+  Read /nɪks oʊ ɛs/ ("Niks Oh Es").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -201,7 +201,7 @@ Terms in parentheses (`(  )`) are abbreviations.
 
   - Nix language
 
-      Programming langauge to declare packages and configurations for the Nix package manager.
+      Programming language to declare packages and configurations for the Nix package manager.
 
     - Nix expression
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -215,4 +215,4 @@ To avoid confusion around all the things called Nix, always use the following te
   - NixOS
 
     Linux distribution based on Nix package manager and `nixpkgs`.
-    Read "Nix Oh Es".
+    Read /nɪks oʊ ɛs/ ("Nix Oh Es").


### PR DESCRIPTION
we observe confusion around terminology.
- newcomers find it hard to distinguish all the things that are called Nix
- Nix is a very generic term that is hard to search for online

this proposal is to introduce just enough structure to clearly distinguish concepts, and give names that are not wrong, without invalidating existing material. therefore it is strictly oriented around existing conventions.

it is *not* intended as an attempt to radically rename ecosystem components, even if that may be desirable for better readability and discoverability.

closes https://github.com/NixOS/nix.dev/issues/275