### PR TITLE
rework notes on search paths

### DIFF
--- a/source/anti-patterns/language.md
+++ b/source/anti-patterns/language.md
@@ -89,20 +89,40 @@ buildInputs = lib.attrVals ["curl" "jq"] pkgs
 
 ## `<...>` search path
 
-`<...>` is syntax, commonly `<nixpkgs>` is for looking up Nix expression's path
-specified by shell environment variable `$NIX_PATH`.
+You will often see Nix language code samples that refer to `<nixpkgs>`.
 
-Two developers on different machines are likely to have `<nixpkgs>` point to different revisions,
-which will lead to getting different results.
+`<...>` is special syntax that was [introduced in 2011][1ecc97b6bd] to conveniently access values from the shell environment variable [`$NIX_PATH`][NIX_PATH].
 
-It's {ref}`possible to specify exact nixpkgs commit <ref-pinning-nixpkgs>` via `$NIX_PATH`,
-but that's still problematic unless:
+This means, the value of a search path depends on external system state.
+When using search paths, the same Nix expression can produce different results.
 
-1. You specify the commit **at one place only** and reference it else where.
-2. And you can control the environment via your source code,
-   so that a) applies by somehow setting `$NIX_PATH` via nix-shell or NixOS options
+In most cases, `$NIX_PATH` is set to the latest channel when Nix is installed, and is therefore likely to differ from machine to machine.
+
+:::{note}
+[Channels](https://nixos.wiki/wiki/Nix_channels) are a way of distributing Nix software.
+They are being phased out, but still used by default.
+:::
+
+For example, two developers on different machines are likely to have `<nixpkgs>` point to different revisions of `nixpkgs`.
+Builds may work for one and fail for the other, causing confusion.
+
+It's <ref-pinning-nixpkgs>`possible to specify an exact \`nixpkgs\` revision ` via `$NIX_PATH`.
+But that is still problematic, unless:
+
+1. you specify the commit **at one place only**,
+
+   and
+
+2. you control the shell environment via your source code, setting `$NIX_PATH` via `nix-shell` or NixOS options.
+
+:::{note}
+We recommend to avoid using search paths and to disable channels by permanently setting `NIX_PATH=` to be empty.
+:::
 
 See {ref}`pinning-nixpkgs` for a tutorial on how to do better.
+
+[1ecc97b6bd]: https://github.com/NixOS/nix/commit/1ecc97b6bdb27e56d832ca48cdafd3dbb5185a04
+[NIX_PATH]: https://nixos.org/manual/nix/unstable/command-ref/env-common.html?highlight=nix_path#env-NIX_PATH
 
 ## `attr1 // attr2` merge operator
 

--- a/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
@@ -13,15 +13,7 @@ In various Nix examples, you'll often see references to [\<nixpkgs>](https://git
 
 This is a **convenient** way to quickly demonstrate a Nix expression and get it working by importing Nix packages.
 
-However, the resulting Nix expression **is not fully reproducible**. The `<nixpkgs>` reference
-is set from the **local** `$NIX_PATH` environment variable. In most cases, this is set at the time Nix is installed
-to the `nixpkgs-unstable` channel, and therefore it is likely to differ from machine to machine.
-
-:::{note}
-[Channels](https://nixos.wiki/wiki/Nix_channels) are a way of distributing Nix software, but they are being phased out.
-Even though they are still used by default, it is recommended to avoid channels
-and `<nixpkgs>` by always setting `NIX_PATH=` to be empty.
-:::
+However, <ref-search-path>`the resulting Nix expression is not fully reproducible`.
 
 ## Pinning packages with URLs inside a Nix expression
 


### PR DESCRIPTION
remove duplication so we can link to the respective section from the
language tutorial