### PR TITLE
remove "Software Nix has influenced"

### DIFF
--- a/source/influences.md
+++ b/source/influences.md
@@ -1,7 +1,0 @@
-# Software Nix has influenced
-
-- https://github.com/alexanderGugel/ied
-- https://www.habitat.sh/
-- https://www.gnu.org/software/guix/
-- https://github.com/andrewchambers/hermes
-- https://bobbuildtool.dev/

--- a/source/reference/index.md
+++ b/source/reference/index.md
@@ -13,5 +13,4 @@ NixOS Manual <https://nixos.org/manual/nixos/stable/>
 pinning-nixpkgs.md
 glossary.md
 ../recommended-reading.md
-../influences.md
 ```


### PR DESCRIPTION
the glossary is empty, and influences are irrelevant for the objective
of learning Nix