### PR TITLE
add bob.build to Software Nix has influenced

### DIFF
--- a/source/influences.md
+++ b/source/influences.md
@@ -4,3 +4,4 @@
 - https://www.habitat.sh/
 - https://www.gnu.org/software/guix/
 - https://github.com/andrewchambers/hermes
+- https://bob.build/


### PR DESCRIPTION
[bob.build ](https://bob.build/docs/)is a build system written in Go, which uses nix for package management. More info [here](https://bob.build/docs/getting-started/package-management) 

