### PR TITLE
add highlighting for shell input/output

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -1,0 +1,4 @@
+div.highlight-shell-session + div.highlight-none pre {
+  background-color: rgba(var(--pst-color-preformatted-text),1) !important;
+  color: rgba(var(--pst-color-preformatted-background),1) !important;
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -168,7 +168,7 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied
@@ -423,3 +423,8 @@ linkcheck_anchors_ignore = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {}
+
+# Custom style sheets
+html_css_files = [
+    'css/custom.css',
+]


### PR DESCRIPTION
This implements highlighting for shell input/output. To use it, two adjacent code blocks must have `shell-session` and none as their highlighting language.

As for how to highlight it, I copied my approach from the Summer of Nix homepage (which itself is based on the German Ubuntu Wiki) and inverted the text/background colours. I’m not sure if that is the best way to handle this here, because the output also gets highlighted and might look weird with inverted colours.

Also, I noticed that Sphinx does not check if the files in `html_static_path` have changed on a rebuild, so they will not be replaced unless a full build is triggered.

cc @fricklerhandwerk