### PR TITLE
Fix typo in Nix language tutorial

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -286,7 +286,7 @@ The most important heuristics to avoid confusion are about white space and paren
    in [ (f a) ]
    ```
 
-       2
+       [ 2 ]
 
    ```nix
    let


### PR DESCRIPTION
Fix the evaluation result of an example which is missing enclosing brackets.