### PR TITLE
nix-language: Don't imply strict eval is a thing

### DIFF
--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -115,10 +115,11 @@ nix-repl> 1 + 2
 ```
 
 :::{note}
-The Nix language by default uses lazy evaluation, and will only compute values when needed.
+The Nix language uses lazy evaluation, and `nix repl` by default only computes values when needed.
 
-Some examples show results of strict evaluation for clarity.
+Some examples show a fully evaluated data structure for clarity.
 If your output does not match the example, try prepending `:p` to the input expression.
+This will compute more of the returned value before showing it.
 
 Example:
 

--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -119,7 +119,6 @@ The Nix language uses lazy evaluation, and `nix repl` by default only computes v
 
 Some examples show a fully evaluated data structure for clarity.
 If your output does not match the example, try prepending `:p` to the input expression.
-This will compute more of the returned value before showing it.
 
 Example:
 

--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -175,7 +175,7 @@ $ nix-instantiate --eval
 :::
 
 :::{note}
-The Nix language uses lazy evaluation, and `nix-instantiate` by default does not compute everything.
+The Nix language uses lazy evaluation, and `nix-instantiate` by default only computes values when needed.
 
 Some examples show a fully evaluated data structure for clarity.
 If your output does not match the example, try adding the `--strict` option to `nix-instantiate`.

--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -176,9 +176,9 @@ $ nix-instantiate --eval
 :::
 
 :::{note}
-The Nix language by default uses lazy evaluation, and will only compute values when needed.
+The Nix language uses lazy evaluation, and `nix-instantiate` by default does not compute everything.
 
-Some examples show results of strict evaluation for clarity.
+Some examples show a fully evaluated data structure for clarity.
 If your output does not match the example, try adding the `--strict` option to `nix-instantiate`.
 
 Example:


### PR DESCRIPTION
This phrases it a bit more accurately, while also using the word `compute` as a correct but general synonym for non-fp novices to grab on to. That said, the last sentence isn't as important to me as the prior edits.