### PR TITLE
Add CODEOWNERS system to nix.dev

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS file
+#
+# This file is used to describe who owns what in this repository. This file does not
+# replace `meta.maintainers` but is instead used for other things than derivations
+# and modules, like documentation, package sets, and other assets.
+#
+# For documentation on this file, see https://help.github.com/articles/about-codeowners/
+# Mentioned users will get code review requests.
+#
+# IMPORTANT NOTE: in order to actually get pinged, commit access is required.
+# This also holds true for GitHub teams. Since almost none of our teams have write
+# permissions, you need to list all members of the team with commit access individually.
+
+# This file
+/.github/CODEOWNERS @domenkozar

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,40 @@
 # permissions, you need to list all members of the team with commit access individually.
 
 # This file
-/.github/CODEOWNERS @domenkozar
+.github/CODEOWNERS @domenkozar
+
+# Dependabot
+.github/dependabot.yml @domenkozar
+
+# GitHub Actions
+.github/workflows/ @domenkozar
+
+# Meta-documentation
+CONTRIBUTING.md @domenkozar
+LICENSE.md @domenkozar
+README.md @domenkozar @fricklerhandwerk
+cla/ @domenkozar
+
+# GitPod
+.gitpod* @domenkozar
+
+# gitignore
+.gitignore @domenkozar
+
+# Nix machinery
+*.nix @domenkozar
+flake.lock @domenkozar
+
+# Python machinery
+poetry.lock @domenkozar
+pyproject.toml @domenkozar
+
+# Build and run machinery
+Makefile @domenkozar
+live* @domenkozar
+runtime.txt @domenkozar
+run_code_block_tests.sh @domenkozar
+.imgbogconfig @domenkozar
+
+# Documentation sources
+source/ @domenkozar @fricklerhandwerk


### PR DESCRIPTION
This PR adds a CODEOWNERS file to nix.dev. This PR should be interpreted largely as a springboard for inline discussion about who should own what. I've leaned heavily toward @domenkozar as the core maintainer of the bulk of this project but am fully open to suggestion on all of the above.
