### PR TITLE
Fix leftovers from .rst -> .md migration

### DIFF
--- a/source/anti-patterns/index.md
+++ b/source/anti-patterns/index.md
@@ -5,5 +5,5 @@ An anti-pattern is a common response to a recurring problem that is usually inef
 ```{toctree}
 :glob: true
 
-language.rst
+language.md
 ```

--- a/source/conf.py
+++ b/source/conf.py
@@ -64,7 +64,7 @@ templates_path = ["_templates"]
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = ".rst"
+source_suffix = ".md"
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/source/index.md
+++ b/source/index.md
@@ -35,13 +35,13 @@ and [NixOps](http://nixos.org/nixops/manual/) manuals.
 :glob: true
 :maxdepth: 3
 
-tutorials/index.rst
-templates/index.rst
-anti-patterns/index.rst
-reference/index.rst
-faq.rst
-recommended-reading.rst
-influences.rst
-glossary.rst
-contributing.rst
+tutorials/index.md
+templates/index.md
+anti-patterns/index.md
+reference/index.md
+faq.md
+recommended-reading.md
+influences.md
+glossary.md
+contributing.md
 ```

--- a/source/reference/index.md
+++ b/source/reference/index.md
@@ -3,5 +3,5 @@
 ```{toctree}
 :glob: true
 
-pinning-nixpkgs.rst
+pinning-nixpkgs.md
 ```

--- a/source/tutorials/index.md
+++ b/source/tutorials/index.md
@@ -3,17 +3,17 @@
 ```{toctree}
 :glob: true
 
-install-nix.rst
-ad-hoc-developer-environments.rst
-nix-language.rst
-towards-reproducibility-pinning-nixpkgs.rst
-declarative-and-reproducible-developer-environments.rst
-continuous-integration-github-actions.rst
-dev-environment.rst
-building-and-running-docker-images.rst
-building-bootable-iso-image.rst
-deploying-nixos-using-terraform.rst
-installing-nixos-on-a-raspberry-pi.rst
-integration-testing-using-virtual-machines.rst
-cross-compilation.rst
+install-nix.md
+ad-hoc-developer-environments.md
+nix-language.md
+towards-reproducibility-pinning-nixpkgs.md
+declarative-and-reproducible-developer-environments.md
+continuous-integration-github-actions.md
+dev-environment.md
+building-and-running-docker-images.md
+building-bootable-iso-image.md
+deploying-nixos-using-terraform.md
+installing-nixos-on-a-raspberry-pi.md
+integration-testing-using-virtual-machines.md
+cross-compilation.md
 ```


### PR DESCRIPTION
Sphinx doesn't care about filetype suffixes so we didn't see any errors.

But it's still nice to do this bit of gardening, I suppose?