### PR TITLE
integration testing: Fix attribute name for interactive testing

### DIFF
--- a/source/tutorials/integration-testing-using-virtual-machines.md
+++ b/source/tutorials/integration-testing-using-virtual-machines.md
@@ -189,7 +189,7 @@ with the script or access a terminal for a machine.
 To interactively start a Python session with a testing framework:
 
 ```shell-session
-$ $(nix-build -A driver postgrest.nix)/bin/nixos-test-driver
+$ $(nix-build -A driverInteractive postgrest.nix)/bin/nixos-test-driver
 ...
 starting VDE switch for network 1
 >>>


### PR DESCRIPTION
According to

https://github.com/NixOS/nixpkgs/blob/70ec3b9f545e9c681e5dfcac10fcde3c4ff1eb87/nixos/doc/manual/development/running-nixos-tests-interactively.section.md#running-tests-interactively-sec-running-nixos-tests-interactively

`driverInteractive` is needed, and just `driver` indeed just runs through without giving me an interactive shell.