### PR TITLE
Rewrite "Set up development environment"

### DIFF
--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -11,10 +11,10 @@ Different ways:
 ## Possible `URL` values
 
 - Local file path. Using just `.` means that nixpkgs is located in current folder.
-- Pinned to a specific commit: `https://github.com/NixOS/nixpkgs/archive/addcb0dddf2b7db505dae5c38fceb691c7ed85f9.tar.gz`
-- Using latest channel, meaning all tests have passed: `http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz`
-- Using latest channel, but hosted by github: `https://github.com/NixOS/nixpkgs/archive/nixos-21.05.tar.gz`
-- Using latest commit for release branch, but not tested yet: `https://github.com/NixOS/nixpkgs/archive/release-21.05.tar.gz`
+- Pinned to a specific commit: `https://github.com/NixOS/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz`
+- Using latest channel, meaning all tests have passed: `http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz`
+- Using latest channel, but hosted by github: `https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz`
+- Using latest commit for release branch, but not tested yet: `https://github.com/NixOS/nixpkgs/archive/release-21.11.tar.gz`
 
 ## Examples
 
@@ -23,19 +23,19 @@ Different ways:
   ```
 
 - ```shell-session
-  $ nix-build -I nixpkgs=http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz`
+  $ nix-build -I nixpkgs=http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz`
   ```
 
 - ```shell-session
-  $ NIX_PATH=nixpkgs=http://nixos.org/channels/nixos-21.05/nixexprs.tar.xz nix-build ...`
+  $ NIX_PATH=nixpkgs=http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz nix-build ...`
   ```
 
 - Using just Nix:
 
   ```nix
   let
-    pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-21.05.tar.gz") {};
-  in pkgs.stdenv.mkDerivation { ... }
+    pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {};
+  in pkgs.stdenv.mkDerivation { … }
   ```
 
 - To make ad-hoc environment available on NixOS: 

--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -35,7 +35,7 @@ Different ways:
   ```nix
   let
     pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {};
-  in pkgs.stdenv.mkDerivation { … }
+  in pkgs.stdenv.mkDerivation { ... }
   ```
 
 - To make ad-hoc environment available on NixOS: 

--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -13,7 +13,7 @@ Different ways:
 - Local file path. Using just `.` means that nixpkgs is located in current folder.
 - Pinned to a specific commit: `https://github.com/NixOS/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz`
 - Using latest channel, meaning all tests have passed: `http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz`
-- Using latest channel, but hosted by github: `https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz`
+- Using latest channel, but hosted by GitHub: `https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz`
 - Using latest commit for release branch, but not tested yet: `https://github.com/NixOS/nixpkgs/archive/release-21.11.tar.gz`
 
 ## Examples

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -102,7 +102,8 @@ $ nix-shell
 ```
 
 As demonstrated, we can use both `curl` and `jq` to test the running web
-application without any manual installation, Nix just does it all for us.
+application without any manual installation.
+Nix does all of that for us.
 
 With the files we created, we can add them to a repository and share them to
 other people. They can now use the same shell environment as long as they have

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -105,8 +105,7 @@ As demonstrated, we can use both `curl` and `jq` to test the running web
 application without any manual installation.
 Nix does all of that for us.
 
-With the files we created, we can add them to a repository and share them to
-other people. They can now use the same shell environment as long as they have
-Nix installed.
+We can commit the files we created to version control and share them with other people.
+Others can now use the same shell environment as long as they have Nix installed.
 
 [virtualenv]: https://virtualenv.pypa.io/en/latest/

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -2,7 +2,7 @@
 
 Let's build a Python web application using the Flask web framework as an exercise.
 
-For our Flask web application, create a new file called `myapp.py` and add the code:
+For our Flask web application, create a new file called `myapp.py` and add the following code:
 
 ```{code-block} python myapp.py
 #! /usr/bin/env python

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -69,7 +69,7 @@ these 93 paths will be fetched (120.19 MiB download, 519.24 MiB unpacked):
 ```
 
 
-Let's use the shell environment to start the web application:
+Let's start the web application within this shell environment:
 
 ```shell-session
 [nix-shell:~/dev-environment]$ python ./myapp.py

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -30,7 +30,7 @@ This is a simple Flask application which serves a JSON document with the message
 To declare the development environment, create a new file `shell.nix`: 
 
 ```{code-block} nix shell.nix
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz") {} }:
 
 pkgs.mkShell {
   packages = [
@@ -46,23 +46,28 @@ pkgs.mkShell {
 
 This creates a shell environment with `python3`, including the `flask` package.
 
-However, it also contains developer tools: `curl` (utility to perform web
-requests) and `jq` (utility to parse and format JSON documents). Both of them
+However, it also contains developer tools: [`curl`] (utility to perform web
+requests) and [`jq`] (utility to parse and format JSON documents). Both of them
 are not Python packages and they are not part of the Python ecosystem.
 
 If we went with Python's [virtualenv], it is not possible to have these
 utilities to be a part of the development environment without additional manual
 steps.
 
+[`curl`]: https://curl.se
+[`jq`]: https://stedolan.github.io/jq/
+[virtualenv]: https://virtualenv.pypa.io/en/latest/
+
 We can now use `nix-shell` to launch the shell environment we just declared:
 
 ```shell-session
 $ nix-shell
 these 2 derivations will be built:
-  /nix/store/w1k2wq0pw53p4h097p9lnfgypzqq6a43-builder.pl.drv
-  /nix/store/911clx564fkrlczx0vwqxsm9wi9ik93c-python3-3.10.6-env.drv
-these 93 paths will be fetched (120.19 MiB download, 519.24 MiB unpacked):
-  /nix/store/0h73sj1n8hzc6fs36cjvsvcvz3av7n47-bash-interactive-5.1-p16
+  /nix/store/5yvz7zf8yzck6r9z4f1br9sh71vqkimk-builder.pl.drv
+  /nix/store/aihgjkf856dbpjjqalgrdmxyyd8a5j2m-python3-3.9.13-env.drv
+these 93 paths will be fetched (109.50 MiB download, 468.52 MiB unpacked):
+  /nix/store/0xxjx37fcy2nl3yz6igmv4mag2a7giq6-glibc-2.33-123
+  /nix/store/138azk9hs5a2yp3zzx6iy1vdwi9q26wv-hook
 ...
 
 [nix-shell:~/dev-environment]$ 
@@ -108,4 +113,4 @@ Nix does all of that for us.
 We can commit the files we created to version control and share them with other people.
 Others can now use the same shell environment as long as they have Nix installed.
 
-[virtualenv]: https://virtualenv.pypa.io/en/latest/
+

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -44,8 +44,7 @@ pkgs.mkShell {
 }
 ```
 
-This creates a shell environment with a Python 3 that contains the `flask`
-library.
+This creates a shell environment with `python3`, including the `flask` package.
 
 However, it also contains developer tools: `curl` (utility to perform web
 requests) and `jq` (utility to parse and format JSON documents). Both of them

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -54,7 +54,7 @@ If we went with Python's [virtualenv], it is not possible to have these
 utilities to be a part of the development environment without additional manual
 steps.
 
-We can now use the `nix-shell` to launch the newly created shell environment:
+We can now use `nix-shell` to launch the shell environment we just declared:
 
 ```shell-session
 $ nix-shell

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -111,5 +111,3 @@ Nix does all of that for us.
 
 We can commit the files we created to version control and share them with other people.
 Others can now use the same shell environment as long as they have Nix installed.
-
-

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -82,8 +82,8 @@ WARNING: This is a development server. Do not use it in a production deployment.
 Press CTRL+C to quit
 ```
 
-We have a running Python web application now, let's try it out using the
-developer tools that are also included.
+We now have a running Python web application now.
+Let's try it out using the developer tools that are also included.
 
 Launch a new terminal to start another session of the shell environment and
 follow the commands below:

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -68,8 +68,6 @@ these 93 paths will be fetched (120.19 MiB download, 519.24 MiB unpacked):
 [nix-shell:~/dev-environment]$ 
 ```
 
-As you can see, Nix will build a working shell environment with the packages you
-defined in `shell.nix`.
 
 Let's use the shell environment to start the web application:
 

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -50,9 +50,8 @@ However, it also contains developer tools: [`curl`] (utility to perform web
 requests) and [`jq`] (utility to parse and format JSON documents). Both of them
 are not Python packages and they are not part of the Python ecosystem.
 
-If we went with Python's [virtualenv], it is not possible to have these
-utilities to be a part of the development environment without additional manual
-steps.
+If we went with Python's [virtualenv], it would not be possible to add these utilities
+to the development environment without additional manual steps.
 
 [`curl`]: https://curl.se
 [`jq`]: https://stedolan.github.io/jq/

--- a/source/tutorials/dev-environment.md
+++ b/source/tutorials/dev-environment.md
@@ -27,8 +27,7 @@ if __name__ == "__main__":
 This is a simple Flask application which serves a JSON document with the message
 "Hello, Nix!".
 
-For the development environment, create a new file `shell.nix` which creates a
-shell environment to be used for development: 
+To declare the development environment, create a new file `shell.nix`: 
 
 ```{code-block} nix shell.nix
 { pkgs ? import <nixpkgs> {} }:


### PR DESCRIPTION
The previous version is specific to Python as it uses `buildPythonApplication` instead of `mkShell`.

This one is more general but maintains the same Python Flask web application example.