### PR TITLE
[Docs] [Tiny PR] Remove duplicated text from Nix Language Docs

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -830,8 +830,6 @@ Example:
 /absolute/path
 ```
 
-    /absolute/path
-
 Paths are relative when they contain at least one slash (`/`) but do not start with one.
 They evaluate to the path relative to the file containing the expression.
 


### PR DESCRIPTION
<img width="662" alt="Screenshot 2022-11-17 at 12 52 42" src="https://user-images.githubusercontent.com/10378052/202451542-8f74c0e0-4287-4ae7-8129-1b089a4021b7.png">

Absolute path is repeated here and I was a bit tired and tried to find the difference 🙈  This PR removes the duplicated documentation line