### PR TITLE
Remove Nix starter template

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -36,7 +36,6 @@ and [NixOps](http://nixos.org/nixops/manual/) manuals.
 :maxdepth: 3
 
 tutorials/index.md
-templates/index.md
 anti-patterns/index.md
 reference/index.md
 faq.md

--- a/source/templates/index.md
+++ b/source/templates/index.md
@@ -1,6 +1,0 @@
-# Templates
-
-## Getting started Nix template
-
-[Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template)
-gives you best practices learned for setting up any kind of development project using Nix.

--- a/source/templates/index.md
+++ b/source/templates/index.md
@@ -1,0 +1,6 @@
+# Templates
+
+- [Nix flake development environment example](https://github.com/nix-dot-dev/nix-flake-example)
+
+- [Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template)
+  gives you best practices learned for setting up any kind of development project using Nix.

--- a/source/tutorials/ad-hoc-developer-environments.md
+++ b/source/tutorials/ad-hoc-developer-environments.md
@@ -158,5 +158,3 @@ We've only covered the bare essentials of Nix here. Once you're comfortable with
 - {ref}`declarative-reproducible-envs` to create reproducible shell environments given a declarative configuration file called a Nix expression.
 - [Garbage Collection](https://nixos.org/manual/nix/stable/package-management/garbage-collection.html)- as when using `nix-shell`, packages are downloaded into `/nix/store`, but never removed.
 - See `man nix-shell` for all of the options.
-- To quickly setup a Nix project read through
-  [Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template).

--- a/source/tutorials/continuous-integration-github-actions.md
+++ b/source/tutorials/continuous-integration-github-actions.md
@@ -72,6 +72,4 @@ you should see status checks appearing on commits and PRs.
 
 ## Next steps
 
-- See [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)
-- To quickly setup a Nix project read through
-  [Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template).
+See [GitHub Actions workflow syntax](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions)

--- a/source/tutorials/declarative-and-reproducible-developer-environments.md
+++ b/source/tutorials/declarative-and-reproducible-developer-environments.md
@@ -138,6 +138,4 @@ hello
 
 ## Next steps
 
-- {ref}`pinning-nixpkgs` to see different ways to import nixpkgs
-- To quickly set up a Nix project read through
-  [Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template).
+{ref}`pinning-nixpkgs` to see different ways to import nixpkgs

--- a/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
@@ -81,6 +81,4 @@ $ nix-shell -p niv --run "niv update"
 
 ## Next steps
 
-- For more examples and details of the different ways to pin `nixpkgs`, see {ref}`ref-pinning-nixpkgs`.
-- To quickly set up a Nix project, read through
-  [Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template).
+For more examples and details of the different ways to pin `nixpkgs`, see {ref}`ref-pinning-nixpkgs`.


### PR DESCRIPTION
On the docs team, we've been discussing ways to change the content of nix.dev to make it more serviceable as an official Nix documentation source. We've decided that the starter template is one of the things that should be removed to that end. To be clear, we're not opposed to the idea of a starter template *per se*, but the one suggested here revolves around a third-party tool ([devenv](https://devenv.sh)).
