### PR TITLE
Update example pinned nixpkgs to a recent one

### DIFF
--- a/source/tutorials/declarative-and-reproducible-developer-environments.md
+++ b/source/tutorials/declarative-and-reproducible-developer-environments.md
@@ -29,7 +29,7 @@ Developer environments allow you to:
 At the top-level of your project create `shell.nix` with the following contents:
 
 ```nix
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz") {} }:
 
 pkgs.mkShell {
   buildInputs = [
@@ -78,7 +78,7 @@ You should see something similar to this:
 Given the following `shell.nix`:
 
 ```nix
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz") {} }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz") {} }:
 
 pkgs.mkShell {
   buildInputs = [

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1456,7 +1456,7 @@ A fully reproducible example would therefore look like this:
 
 ```nix
 let
-  nixpkgs = fetchTarball https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz;
+  nixpkgs = fetchTarball https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz;
   pkgs = import nixpkgs {};
 in
 pkgs.lib.strings.toUpper "always pin your sources"

--- a/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/towards-reproducibility-pinning-nixpkgs.md
@@ -22,7 +22,7 @@ To create **fully reproducible** Nix expressions, we can pin an exact version of
 The simplest way to do this is to fetch the required Nixpkgs version as a tarball specified via the relevant Git commit hash:
 
 ```nix
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/3590f02e7d5760e52072c1a729ee2250b5560746.tar.gz") {}
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz") {}
 }:
 
 ...


### PR DESCRIPTION
The pinned nixpkgs in these examples does not work with more recent versions of nix.

Fixes #419