### PR TITLE
Make install command in documentation compatible with fish shell

### DIFF
--- a/source/tutorials/install-nix.md
+++ b/source/tutorials/install-nix.md
@@ -7,19 +7,11 @@
 Install Nix via the recommended [multi-user installation]:
 
 ```shell-session
-$ sh <(curl -L https://nixos.org/nix/install) --daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 :::{note}
 For security you may want to [verify the installation script] using GPG signatures.
-:::
-
-:::{note}
-If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
-
-```fish
-$ sh (curl -L https://nixos.org/nix/install | psub) --daemon
-```
 :::
 
 ## macOS
@@ -27,19 +19,11 @@ $ sh (curl -L https://nixos.org/nix/install | psub) --daemon
 Install Nix via the recommended [multi-user installation]:
 
 ```shell-session
-$ sh <(curl -L https://nixos.org/nix/install)
+$ curl -L https://nixos.org/nix/install | sh
 ```
 
 :::{note}
 For security you may want to [verify the installation script] using GPG signatures.
-:::
-
-:::{note}
-If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
-
-```fish
-$ sh (curl -L https://nixos.org/nix/install | psub)
-```
 :::
 
 ## Windows (WSL2)
@@ -47,25 +31,17 @@ $ sh (curl -L https://nixos.org/nix/install | psub)
 Install Nix via the recommended [single-user installation]:
 
 ```shell-session
-$ sh <(curl -L https://nixos.org/nix/install) --no-daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --no-daemon
 ```
 
 However, if you have [systemd support] enabled, install Nix via the recommended [multi-user installation]:
 
 ```shell-session
-$ sh <(curl -L https://nixos.org/nix/install) --daemon
+$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
 ```
 
 :::{note}
 For security you may want to [verify the installation script] using GPG signatures.
-:::
-
-:::{note}
-If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
-
-```fish
-$ sh (curl -L https://nixos.org/nix/install | psub) --daemon
-```
 :::
 
 [systemd support]: https://learn.microsoft.com/en-us/windows/wsl/wsl-config#systemd-support

--- a/source/tutorials/install-nix.md
+++ b/source/tutorials/install-nix.md
@@ -14,6 +14,14 @@ $ sh <(curl -L https://nixos.org/nix/install) --daemon
 For security you may want to [verify the installation script] using GPG signatures.
 :::
 
+:::{note}
+If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
+
+```fish
+$ sh (curl -L https://nixos.org/nix/install | psub) --daemon
+```
+:::
+
 ## macOS
 
 Install Nix via the recommended [multi-user installation]:
@@ -24,6 +32,14 @@ $ sh <(curl -L https://nixos.org/nix/install)
 
 :::{note}
 For security you may want to [verify the installation script] using GPG signatures.
+:::
+
+:::{note}
+If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
+
+```fish
+$ sh (curl -L https://nixos.org/nix/install | psub)
+```
 :::
 
 ## Windows (WSL2)
@@ -42,6 +58,14 @@ $ sh <(curl -L https://nixos.org/nix/install) --daemon
 
 :::{note}
 For security you may want to [verify the installation script] using GPG signatures.
+:::
+
+:::{note}
+If using [fish shell](https://fishshell.com/) there is different syntax for process substitution:
+
+```fish
+$ sh (curl -L https://nixos.org/nix/install | psub) --daemon
+```
 :::
 
 [systemd support]: https://learn.microsoft.com/en-us/windows/wsl/wsl-config#systemd-support


### PR DESCRIPTION
With the [fish shell support](https://github.com/NixOS/nix/pull/7014) added earlier this year, Nix supports installations in fish shell out of the box. The installation instructions still use process substitution syntax that's specific to other shells (eg. bash & zsh), so users installing Nix from fish shell must translate the command before the installation will work.

This PR makes the install commands in the installation instructions compatible with fish shell.

Running the current install command in fish produces
```fish
$ sh <(curl -L https://nixos.org/nix/install)
...
fish: Invalid redirection target: 
sh <(curl -L https://nixos.org/nix/install)
   ^
```

Running the command with the correct fish syntax starts the installer (also tested with the `--daemon` flag passed to the installer)
```fish
$ curl -L https://nixos.org/nix/install | sh
...
Switching to the Multi-user Installer
Welcome to the Multi-User Nix Installation
...
```