### PR TITLE
add note on providing commit access to maintainers

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -84,6 +84,9 @@ Ordered by priority:
   - announce meetings on the calendar
   - moderate and keep schedule
   - take and publish notes
+- support maintainers
+  - assist new maintainers to get commit access
+    ([NixOS GitHub organisation owners](https://github.com/orgs/NixOS/people?query=role%3Aowner) can hand out permissions)
 
 ## Team meetings
 


### PR DESCRIPTION
this is to make the process more discoverable. it still needs more details, but we can provide those as needed, probably in a separate document.

fixes #365 