### PR TITLE
Fixed a minor function spelling error in nix-language.md

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -2042,7 +2042,7 @@ This example is a (simplified) package declaration from Nixpkgs.
 Explanation:
 
 - This expression is a function that takes an attribute set which must have exactly the attributes `lib` and `stdenv`.
-- It returns the result of evaluating the function `mkDerivaion`, which is an attribute of `stdenv`, applied to a recursive set.
+- It returns the result of evaluating the function `mkDerivation`, which is an attribute of `stdenv`, applied to a recursive set.
 - The recursive set passed to `mkDerivation` uses its own `pname` and `version` attributes in the argument to the built-in function `fetchTarball`.
 - The `meta` attribute is itself an attribute set, where the `license` attribute has the value that was assigned to the nested attribute `lib.licenses.gpl3Plus`.
 


### PR DESCRIPTION
Yeah, I fixed a really minor spelling error that might've confused some NixOS newcomers. Yes, I fixed this just to be able to call myself a "NixOS contributor"