### PR TITLE
remove redundant terms from glossary

### DIFF
--- a/source/glossary.md
+++ b/source/glossary.md
@@ -1,9 +1,6 @@
 # Glossary
 
 ```{glossary}
-attribute name
-    Attribute sets are a collection of key/value pairs. The attribute name is the key.
-
 Nix
     Build system and package manager.
 
@@ -27,9 +24,6 @@ NixOS
     Linux distribution based on Nix and Nixpkgs.
 
     Read /nɪks oʊ ɛs/ ("Niks Oh Es").
-
-package name
-    TODO
 
 reproducible
     Reproducibility would guarantee exactly the same results no matter


### PR DESCRIPTION
we should always link to authoritative definitions of terms when they
exist, instead of doing double book keeping here.

"attribute name" should be uniquely defined in the Nix reference manual.

"package name" should be uniquely defined in the Nixpkgs manual.