### PR TITLE
fix: typo in the code example

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -850,7 +850,7 @@ Example:
 let
   a = "no";
 in
-"${a + "${a + " ${a}"}"}"
+"${a + " ${a + " ${a}"}"}"
 ```
 
 ```{code-block}


### PR DESCRIPTION
The code example has a typo. One space is missing.

Original code example produces the following output:

```
"nono no"
```

but the expected result is 

```
"no no no"
```