### PR TITLE
fixups to pinning overview

### DIFF
--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -2,19 +2,47 @@
 
 # Pinning Nixpkgs
 
-Different ways:
+Specifying remote Nix expressions, such as the one provided by Nixpkgs, can be done in several ways:
 
-- As environment variable: `$NIX_PATH=URL`
-- `-I` command line parameter to most of commands like `nix-build`, `nix-shell`, etc
-- Using [builtins.fetchTarball](https://nixos.org/manual/nix/stable/expressions/builtins.html) function that fetches the channel at evaluation time
+- [`-I` option](https://nixos.org/manual/nix/stable/command-ref/opt-common.html#opt-I) to most of commands like `nix-build`, `nix-shell`, etc.
+- [`$NIX_PATH` environment variable](https://nixos.org/manual/nix/stable/command-ref/env-common.html#env-NIX_PATH)
+- Using [builtins.fetchTarball](https://nixos.org/manual/nix/stable/expressions/builtins.html) to fetch a Nix expression at evaluation time
 
 ## Possible `URL` values
 
-- Local file path. Using just `.` means that nixpkgs is located in current folder.
-- Pinned to a specific commit: `https://github.com/NixOS/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz`
-- Using latest channel, meaning all tests have passed: `http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz`
-- Using latest channel, but hosted by GitHub: `https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz`
-- Using latest commit for release branch, but not tested yet: `https://github.com/NixOS/nixpkgs/archive/release-21.11.tar.gz`
+- Local file path.
+
+  Using `.` means that nixpkgs is located in the current directory.
+
+- Pinned to a specific commit
+
+  ```
+  https://github.com/NixOS/nixpkgs/archive/eabc38219184cc3e04a974fe31857d8e0eac098d.tar.gz
+  ```
+
+- Using the latest channel version, meaning all tests have passed
+
+  ```
+  http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz
+  ```
+
+  Shorthand syntax for `NIX_PATH` and `-I`:
+
+  ```
+  channel:nixos-22.11`
+  ```
+
+- Using the latest channel version, hosted by GitHub
+
+  ```
+  https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz
+  ```
+
+- Using the latest commit on the release branch, but not tested yet
+
+  ```
+  https://github.com/NixOS/nixpkgs/archive/release-21.11.tar.gz
+  ```
 
 ## Examples
 
@@ -27,20 +55,21 @@ Different ways:
   ```
 
 - ```shell-session
+  $ nix-build -I nixpkgs=channel:nixos-22.11`
+  ```
+
+- ```shell-session
   $ NIX_PATH=nixpkgs=http://nixos.org/channels/nixos-22.11/nixexprs.tar.xz nix-build ...`
   ```
 
-- Using just Nix:
+- ```shell-session
+  $ NIX_PATH=nixpkgs=channel:nixos-22.11 nix-build ...`
+  ```
+
+- In the Nix language:
 
   ```nix
   let
     pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {};
   in pkgs.stdenv.mkDerivation { ... }
-  ```
-
-- To make ad-hoc environment available on NixOS: 
-  ```nix
-  {
-    nix.nixPath = [ ("nixpkgs=" + toString pkgs.path) ];
-  }
   ```

--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -12,7 +12,7 @@ Specifying remote Nix expressions, such as the one provided by Nixpkgs, can be d
 
 - Local file path.
 
-  Using `.` means that nixpkgs is located in the current directory.
+  Using `./.` means that the expression is located in a file `default.nix` the current directory.
 
 - Pinned to a specific commit
 


### PR DESCRIPTION
remove the NixOS example, as the sample has lots of caveats, such as
having to rebuild NixOS a second time to make it effective.