### PR TITLE
Enable deploy previews for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
-name: "CI"
-on: 
-- pull_request
-- push
+name: "Build"
+
+on:
+  push: {}
+  pull_request: {}
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -19,7 +20,13 @@ jobs:
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - name: Build
       run: nix-build
-    - name: Linkcheck
-      run: nix-shell --run "make linkcheck"
-    - name: Run code block tests
-      run: nix-shell --run "./run_code_block_tests.sh"
+    - name: Copy build from Nix store
+      run: |
+        cp -r -L result real-result
+        rm result
+        mv real-result result
+    - name: Upload artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: build
+        path: result/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,12 +21,19 @@ jobs:
     - name: Build
       run: nix-build
     - name: Copy build from Nix store
+      if: github.event_name == 'pull_request'
       run: |
         cp -r -L result real-result
         rm result
         mv real-result result
-    - name: Upload artifact
+    - name: Save PR number
+      if: github.event_name == 'pull_request'
+      run: echo ${{ github.event.number }} > .github/pr
+    - name: Upload artifact for deploy preview
       uses: actions/upload-artifact@v3
+      if: github.event_name == 'pull_request'
       with:
-        name: build
-        path: result/
+        name: pr
+        path: |
+          result/
+          .github/pr

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: "Deploy"
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifact
+        uses: actions/github-script@v6
+        with:
+          script: |
+            let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               run_id: context.payload.workflow_run.id,
+            });
+            let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+              return artifact.name == "pr"
+            })[0];
+            let download = await github.rest.actions.downloadArtifact({
+               owner: context.repo.owner,
+               repo: context.repo.repo,
+               artifact_id: matchArtifact.id,
+               archive_format: 'zip',
+            });
+            let fs = require('fs');
+            fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/artifact.zip`, Buffer.from(download.data));
+      - name: Extract artifact
+        run: unzip artifact.zip
+      - name: Retrieve PR number
+        id: pr
+        run: echo "id=$(cat .github/pr)" >> $GITHUB_OUTPUT
+      - name: Deploy preview
+        id: deploy
+        uses: cloudflare/pages-action@1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+          directory: ./result
+          branch: pr-${{ steps.pr.outputs.id }}
+      - name: Create comment on PR
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ steps.pr.outputs.id }}
+          edit-mode: replace
+          body: |
+            <!-- Deploy Preview Comment -->
+            # Deploy Preview
+            <table>
+              <tr>
+                <th>Name</th>
+                <th>Result</th>
+              </tr>
+              <tr>
+                <td><b>Last commit:</b></td>
+                <td>
+                  <a href='https://github.com/${{ github.repository }}/commit/${{ github.event.workflow_run.head_sha }}'>
+                    <code>${{ github.event.workflow_run.head_sha }}</code>
+                  </a>
+                </td>
+              <tr>
+              <tr>
+                <td><b>Preview URL:</b></td>
+                <td><a href='${{ steps.deploy.outputs.url }}'>${{ steps.deploy.outputs.url }}</td>
+            </table>

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,39 @@
+name: "Test"
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+       fetch-depth: 0
+    - uses: cachix/install-nix-action@v20
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v12
+      with:
+        name: nix-dev
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: Run linkcheck
+      run: nix-shell --run "make linkcheck"
+  codeblock:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+       fetch-depth: 0
+    - uses: cachix/install-nix-action@v20
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: cachix/cachix-action@v12
+      with:
+        name: nix-dev
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - name: Run builder
+      run: nix-shell --run "make dummy"
+    - name: Test code blocks
+      run: nix-shell --run "./run_code_block_tests.sh"


### PR DESCRIPTION
The proposed set of changes aims to improve CI by enabling deploy previews for forks (via manual deployments to Cloudflare Pages from GitHub CI).

Before merging this change, the following needs to be done:
- Define [`CLOUDFLARE_API_TOKEN`](https://github.com/cloudflare/pages-action#generate-an-api-token) as a [repository secret].
- Define [`CLOUDFLARE_ACCOUNT_ID`](https://github.com/cloudflare/pages-action#get-account-id) as a repository secret.
- Define `CLOUDFLARE_PROJECT_NAME` as a [repository variable].

[repository secret]: https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository
[repository variable]: https://docs.github.com/en/actions/learn-github-actions/variables#creating-configuration-variables-for-a-repository