### PR TITLE
NIX_PATH includes nixpkgs in cross-compilation.md

### DIFF
--- a/source/tutorials/cross-compilation.md
+++ b/source/tutorials/cross-compilation.md
@@ -37,7 +37,7 @@ Since this is rarely needed, we will assume that the target is identical to the 
 To ensure the reproducibility of this tutorial as explained in {ref}`the pinning tutorial <pinning-nixpkgs>`:
 
 ```shell-session
-$ NIX_PATH=https://github.com/NixOS/nixpkgs/archive/9420363b95521e65a76eb5153de1eaee4a2e41c6.tar.gz
+$ NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/9420363b95521e65a76eb5153de1eaee4a2e41c6.tar.gz
 ```
 
 ## Determining the host platform config


### PR DESCRIPTION
I believe this is required for the following commands to work with the pinned version of nixpkgs.