### PR TITLE
Add doc structure proposal

### DIFF
--- a/maintainers/working_groups/learning_journey/README.md
+++ b/maintainers/working_groups/learning_journey/README.md
@@ -28,42 +28,9 @@ Membership is open to anyone that wants to contribute.
 Meetings will be held every week to ensure that progress can be made between meetings.
 
 ## Immediate projects
-### Decide on documentation structure
-This project will decide on a high level structure for the documentation so that contributors know the audience they are speaking to and where their contributions fit into the Nix documentation landscape.
 
-The documentation will follow the [Diataxis](https://diataxis.fr) framework to the degree that it makes sense. This project will produce a proposal to be submitted to the Documentation Team.
-
-The first draft of this structure is as follows:
-- Tutorials
-    - Installation of Nix
-    - Walking a user through their first derivation
-    - Packaging an existing project for Nix for the first time
-- How-To
-    - Packaging for specific languages
-    - Packaging idioms
-        - `callPackage`, "import from derivation", "fixed output derivation", etc
-    - Day-to-day development and workflows
-        - Integration with IDEs/editors
-        - Nix in CI
-        - Nix and NixOS deployments
-        - Building containers
-    - Rollbacks
-    - Contributing in various ways
-- Explanation
-    - Concepts
-    - What is a derivation?
-    - Cross-compilation as a first-class citizen
-        - Where to put your dependencies (`buildInputs`, `nativeBuildInputs`, etc)
-    - The Nix Store and the database
-    - Channels, profiles, etc
-    - Overlays, overrides, `follows`
-- Reference
-    - Command reference
-    - How store paths are computed
-    - Build phases
-    - How derivations work
-    - Nix language reference
-    - Flake schema
+### Establish structure of documentation
+In order to unblocked contributions, the first priority is deciding on a documentation structure. We should be able to direct new contributors to the exact place to put the materials they want to contribute and understand beforehand whether a contribution overlaps with existing documentation.
 
 ### Set standards for documentation pages
 In order to provide a level of consistent quality for the documentation, we should decide on the bare minimum standards for documentation pages.

--- a/maintainers/working_groups/learning_journey/README.md
+++ b/maintainers/working_groups/learning_journey/README.md
@@ -30,7 +30,7 @@ Meetings will be held every week to ensure that progress can be made between mee
 ## Immediate projects
 
 ### Establish structure of documentation
-In order to unblocked contributions, the first priority is deciding on a documentation structure. We should be able to direct new contributors to the exact place to put the materials they want to contribute and understand beforehand whether a contribution overlaps with existing documentation.
+In order to unblock contributions, the first priority is deciding on a documentation structure. We should be able to direct new contributors to the exact place to put the materials they want to contribute and understand beforehand whether a contribution overlaps with existing documentation.
 
 ### Set standards for documentation pages
 In order to provide a level of consistent quality for the documentation, we should decide on the bare minimum standards for documentation pages.

--- a/maintainers/working_groups/learning_journey/README.md
+++ b/maintainers/working_groups/learning_journey/README.md
@@ -30,7 +30,7 @@ Meetings will be held every week to ensure that progress can be made between mee
 ## Immediate projects
 
 ### Establish structure of documentation
-In order to unblock contributions, the first priority is deciding on a documentation structure. We should be able to direct new contributors to the exact place to put the materials they want to contribute and understand beforehand whether a contribution overlaps with existing documentation.
+In order to unblock contributions, the first priority is deciding on a documentation structure. We should be able to direct new contributors to the exact place to put the materials they want to contribute and understand beforehand whether a contribution overlaps with existing documentation. The documentation will be organized using the [Diataxis](https://diataxis.fr) framework, so that tutorials, how-to guides, explanatory materials, and reference materials are clearly separated.
 
 ### Set standards for documentation pages
 In order to provide a level of consistent quality for the documentation, we should decide on the bare minimum standards for documentation pages.

--- a/maintainers/working_groups/learning_journey/documentation-structure.md
+++ b/maintainers/working_groups/learning_journey/documentation-structure.md
@@ -1,0 +1,24 @@
+- Tutorials
+    - Nix
+    - NixOS
+- How-To
+    - Language guides
+    - Workflows
+        - Nix REPL
+        - IDE integration
+        - CI
+        - Operations
+        - Containers
+        - Shells
+    - Package management
+    - Contributing
+- Explanation
+    - Nix store
+    - Cross-compilation
+    - Packaging conventions
+- Reference
+    - Nix language reference
+    - Commands reference
+    - Derivations
+    - Nix built-ins
+    - Nixpkgs lib

--- a/maintainers/working_groups/learning_journey/documentation-structure.md
+++ b/maintainers/working_groups/learning_journey/documentation-structure.md
@@ -1,8 +1,14 @@
 - Tutorials
-    - Nix
-    - NixOS
+    - First steps
+        - Nix
+        - Declarative configuration management
+    - Nix workflows (name needs bikeshedding)
+    - Declarative configuration management (name needs bikeshedding)
 - How-To
     - Language guides
+        - Rust
+        - Python
+        - etc
     - Workflows
         - Nix REPL
         - IDE integration
@@ -11,11 +17,13 @@
         - Containers
         - Shells
     - Package management
+    - Configuration management
     - Contributing
 - Explanation
     - Nix store
     - Cross-compilation
     - Packaging conventions
+    - Module system
 - Reference
     - Nix language reference
     - Commands reference


### PR DESCRIPTION
This PR adds a proposed documentation structure. Notably it does not change the structure of the `nix.dev` site, that would happen in a separate PR pending approval by the documentation team. This PR is meant to be a means of async discussion on the structure of the documentation.

The outline in `documentation-structure.md` is intended to be the skeleton of the documentation structure and specifically does not include a list of articles we intend to write/migrate. Articles would go directly under each of the leaf-node entries in the outline in `documentation-structure.md` once we have an approved documentation structure.