### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-documentation-page-suggestion.md
+++ b/.github/ISSUE_TEMPLATE/new-documentation-page-suggestion.md
@@ -1,0 +1,16 @@
+---
+name: New Documentation Page Suggestion
+about: Suggest a new documentation page
+title: 'New Page: PAGE DESCRIPTION'
+labels: new_docs
+assignees: ''
+
+---
+
+**Briefly describe the contents of the page**
+
+**Which type of documentation is this?**
+<!-- Choose from: tutorial, recipe, concept, reference -->
+
+**Is there prior art? If so, list any relevant materials**
+<!-- List any other pages, blog posts, videos, etc that cover this topic -->

--- a/.github/ISSUE_TEMPLATE/site-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/site-enhancement.md
@@ -1,0 +1,14 @@
+---
+name: Site Enhancement
+about: Suggest an improvement to nix.dev
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Suggestion**
+<!-- What would you like to see changed? -->
+
+**Willing to help?**
+<!-- Are you willing to help make the change? -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,15 @@
+---
+name: Task
+about: Record information about a task that needs to be done
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**What needs to be done?**
+<!-- Describe in detail the work that needs to be done -->
+
+**Does this require buy-in from anyone? If yes, who?**
+
+**Is this task blocked by any other tasks? If so, link them here**

--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -1,0 +1,17 @@
+---
+name: Tracking Issue
+about: Create a tracking issue for a project or piece of work
+title: Tracking Issue - PROJECT DESCRIPTION
+labels: tracking
+assignees: ''
+
+---
+
+## Project description
+<!-- Briefly describe the project to provide context for the work that needs to be done -->
+
+## Steps
+<!-- List the steps that are required to deliver the project, linking issues and PRs for each step as they are opened -->
+
+- [ ] Step 1
+- [ ] Step 2


### PR DESCRIPTION
This PR adds issue templates for the following items:
- Suggesting new documentation pages
    - Automatically adds a `new_docs` label, which needs to be created
- Site enhancement
    - Is there something that could be better about `nix.dev` itself? (styling, markup, etc)
- Task
    - Work items, suggests that you list any issues blocking the new task
- Tracking issue
    - An issue that breaks down a project into a sequence of subtasks
    - Automatically assigns the `tracking` label

You can always create blank/custom issues by selecting "Open a blank issue" at the bottom of the list of issue templates. This list of issue templates isn't meant to be restrictive, it's meant to automate part of the process of keeping track of work that needs to be done with minimal overhead.