### PR TITLE
Add missing trailing newline in multi-line string example

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1033,7 +1033,7 @@ string
 
 ```{code-block}
 :class: value
-"multi\nline\nstring"
+"multi\nline\nstring\n"
 ```
 
 Equal amounts of prepended white space are trimmed from the result.


### PR DESCRIPTION
I was just checking out the [Nix language basics](https://nixos.org/guides/nix-language.html) and found the example of multi-line strings a bit odd as it exhibits different (and weirder) behavior than Python `"""` strings and is inconsistent with the second example. Checking with the NixOS Virtualbox image shows that in reality, the behavior is as expected and this seems to be a typo :)