### PR TITLE
Explain what chained script interpreter construct is

### DIFF
--- a/source/tutorials/reproducible-scripts.md
+++ b/source/tutorials/reproducible-scripts.md
@@ -63,7 +63,8 @@ Create a file named `nixpkgs-releases.sh` with the following content:
 curl https://github.com/NixOS/nixpkgs/releases.atom | xml2json | jq .
 ```
 
-The first line is a standard hashbang. The additional hashbang lines are a Nix specific construct. The rest of the file is taken to be bash code because of the `-i bash` parameter.
+The first line is a standard shebang.
+The additional shebang lines are a Nix-specific construct.
 
 We specify the `bash` program as the interpreter with the `-i` option.
 

--- a/source/tutorials/reproducible-scripts.md
+++ b/source/tutorials/reproducible-scripts.md
@@ -66,7 +66,7 @@ curl https://github.com/NixOS/nixpkgs/releases.atom | xml2json | jq .
 The first line is a standard shebang.
 The additional shebang lines are a Nix-specific construct.
 
-We specify the `bash` program as the interpreter with the `-i` option.
+We specify `bash` as the interpreter for the rest of the file with the `-i` option.
 
 We enable the `--pure` option to prevent the script from implicitly using programs that may already exist on the system that will run the script.
 

--- a/source/tutorials/reproducible-scripts.md
+++ b/source/tutorials/reproducible-scripts.md
@@ -63,7 +63,10 @@ Create a file named `nixpkgs-releases.sh` with the following content:
 curl https://github.com/NixOS/nixpkgs/releases.atom | xml2json | jq .
 ```
 
+The first line is a standard hashbang. The additional hashbang lines are a Nix specific construct. The rest of the file is taken to be bash code because of the `-i bash` parameter.
+
 We specify the `bash` program as the interpreter with the `-i` option.
+
 We enable the `--pure` option to prevent the script from implicitly using programs that may already exist on the system that will run the script.
 
 With the `-p` option we specify the packages required for the script to run.


### PR DESCRIPTION
> The chained script interpreter to be invoked

Chained is mentioned here but then also forgotten about: https://nixos.org/manual/nix/unstable/command-ref/nix-shell.html

Mostly it's unclear here why there are multiple weird hashbang lines there that are the same.

Also it's not great that here an entirely new construct is introduced that probably nobody will have ever seen before and to understand what it does you have to go to several different off-site documentation pages.

Can this be rewritten to be more standalone?