### PR TITLE
Fix typos in This Month in Nix Docs script

### DIFF
--- a/maintainers/this-month-in-nix-docs/README.md
+++ b/maintainers/this-month-in-nix-docs/README.md
@@ -3,7 +3,7 @@ This is a script and template for compiling "This Month in Nix Docs". The proces
 
 A new post is created via:
 ```
-$ ./new-post.sh <from YYYY-MM-DD> <to YYYY-MM-DD> > new-post.md
+$ ./make-post.sh <from YYYY-MM-DD> <to YYYY-MM-DD> > new-post.md
 ```
 
 After this invocation a template post (`new-post.md`) will be filled out with the GitHub query results formatted as markdown at the end of the file.

--- a/maintainers/this-month-in-nix-docs/make-post.sh
+++ b/maintainers/this-month-in-nix-docs/make-post.sh
@@ -44,7 +44,7 @@ list_new_tracking_issues() {
 }
 
 cat << EOF
-# This Month in Nix Docs - #**NUMBER** - **MONTH** **YEAR**
+# This Month in Nix Docs - #NUMBER - MONTH YEAR
 
 ## Community
 The Documentation Team can be found in a number of places. Check the [Documentation Team page](https://nixos.org/community/teams/documentation.html) and drop in if you'd like to contribute!


### PR DESCRIPTION
This PR fixes a typo in the README for using this script and removes the bold formatting around the post title generated by the script.