### PR TITLE
Fix link to renamed anchor

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -410,6 +410,8 @@ linkcheck_ignore = [
     r"https://matrix.to",
     # returns 403 on CI
     r"https://www.lesswrong.com",
+    # Linkcheck fails on anchors in GH READMEs, see https://github.com/sphinx-doc/sphinx/issues/9016
+    r"https://github.com/cachix/install-nix-action#how-do-i-run-nixos-tests"
 ]
 
 # Anchors are not present in HTML

--- a/source/tutorials/integration-testing-using-virtual-machines.md
+++ b/source/tutorials/integration-testing-using-virtual-machines.md
@@ -216,5 +216,5 @@ Linux server 5.10.37 #1-NixOS SMP Fri May 14 07:50:46 UTC 2021 x86_64 GNU/Linux
 
 - Running integration tests on CI requires hardware acceleration, which many CIs do not support.
   To run integration tests on {ref}`GitHub Actions <github-actions>` see
-  [how to disable hardware acceleration](https://github.com/cachix/install-nix-action#user-content-how-can-i-run-nixos-tests).
+  [how to disable hardware acceleration](https://github.com/cachix/install-nix-action#how-do-i-run-nixos-tests).
 - NixOS comes with a large set of tests that serve also as educational examples. A good inspiration is [Matrix bridging with an IRC](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/matrix/appservice-irc.nix).


### PR DESCRIPTION
This PR fixes a link that was broken when an anchor in the `cachix/install-nix-action` README was changed.