### PR TITLE
Create an issue template for tracking issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -1,7 +1,6 @@
 ---
 name: Tracking Issue
 about: Create a tracking issue for a collection of issues and pull-requests
-title: Tracking Issue - PROJECT DESCRIPTION
 labels: tracking
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -2,8 +2,6 @@
 name: Tracking Issue
 about: Create a tracking issue for a collection of issues and pull-requests
 labels: tracking
-assignees: ''
-
 ---
 
 ## Project description

--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -8,7 +8,7 @@ labels: tracking
 <!-- Briefly describe the project to provide context for the work that needs to be done -->
 
 ## Steps
-<!-- List the steps that are required to deliver the project, linking issues and PRs for each step as they are opened -->
+<!-- List the steps that are required to finish the project, and link issues and pull requests -->
 
 - [ ] Step 1
 - [ ] Step 2

--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -1,6 +1,6 @@
 ---
 name: Tracking Issue
-about: Create a tracking issue for a project or piece of work
+about: Create a tracking issue for a collection of issues and pull-requests
 title: Tracking Issue - PROJECT DESCRIPTION
 labels: tracking
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/tracking-issue.md
+++ b/.github/ISSUE_TEMPLATE/tracking-issue.md
@@ -1,0 +1,17 @@
+---
+name: Tracking Issue
+about: Create a tracking issue for a project or piece of work
+title: Tracking Issue - PROJECT DESCRIPTION
+labels: tracking
+assignees: ''
+
+---
+
+## Project description
+<!-- Briefly describe the project to provide context for the work that needs to be done -->
+
+## Steps
+<!-- List the steps that are required to deliver the project, linking issues and PRs for each step as they are opened -->
+
+- [ ] Step 1
+- [ ] Step 2


### PR DESCRIPTION
This PR adds an issue template for creating new tasks. The benefit over a free-form issue in this case is that it prompts the user to fill out as much context as possible, which is often missing from free-form issues.