### PR TITLE
Create an issue template for site improvements

### DIFF
--- a/.github/ISSUE_TEMPLATE/site.md
+++ b/.github/ISSUE_TEMPLATE/site.md
@@ -1,0 +1,14 @@
+---
+name: Site improvement
+about: Suggest an improvement to nix.dev (fix typos, styling, etc)
+title: ''
+labels: site
+assignees: ''
+
+---
+
+**Suggestion**
+<!-- What would you like to see changed? -->
+
+**Willing to help?**
+<!-- Are you willing to help make the change? -->

--- a/.github/ISSUE_TEMPLATE/site.md
+++ b/.github/ISSUE_TEMPLATE/site.md
@@ -1,14 +1,22 @@
 ---
 name: Site improvement
-about: Suggest an improvement to nix.dev (fix typos, styling, etc)
-title: ''
+about: Suggest an improvement to nix.dev (styling, content structure, technical infrastructure, etc.)
 labels: site
-assignees: ''
 
 ---
 
-**Suggestion**
-<!-- What would you like to see changed? -->
+**Observations**
+<!-- What is it that you're seeing? What are the symptoms? -->
+
+**Problem**
+<!-- Given what you're observing, what's the problem? -->
+
+**Approaches**
+<!-- Do you know of any potential solutions? If so, list them here. -->
 
 **Willing to help?**
 <!-- Are you willing to help make the change? -->
+
+**Priorities**
+
+Add :+1: to [issues you find important](https://github.com/NixOS/nix.dev/issues?q=is%3Aissue+is%3Aopen+sort%3Areactions-%2B1-desc).


### PR DESCRIPTION
This PR adds an issue template for suggesting improvements to nix.dev, specifically calling out things like typos, styling, etc. This issue template is meant to narrowly cover presentation, not documentation contents.