### PR TITLE
Add more templates

### DIFF
--- a/source/templates/index.md
+++ b/source/templates/index.md
@@ -1,6 +1,14 @@
 # Templates
 
-## Getting started Nix template
+## Generic
 
-[Getting started Nix template](https://github.com/nix-dot-dev/getting-started-nix-template)
-gives you best practices learned for setting up any kind of development project using Nix.
+### [Getting started Nix template][getting-started-nix-template]
+
+Provides an example baseline development environment using
+[`devenv.sh`][devenv].
+
+[getting-started-nix-template]: https://github.com/nix-dot-dev/getting-started-nix-template
+
+<!-- General links -->
+
+[devenv]: https://devenv.sh

--- a/source/templates/index.md
+++ b/source/templates/index.md
@@ -9,6 +9,33 @@ Provides an example baseline development environment using
 
 [getting-started-nix-template]: https://github.com/nix-dot-dev/getting-started-nix-template
 
+## Python
+
+### [Nix + Python Quickstart][nix-python-quickstart]
+
+A [`cargo-generate`][cargo-generate] project template for use with Flakes,
+[`direnv`][direnv], and [`nix-direnv`][nix-direnv]. Generated projects are
+fully-featured but not tailored for any specific use-case, including things such
+as a development environment, a package expression, and continuous integration
+tooling.
+
+[nix-python-quickstart]: https://or.computer.surgery/charles/nix-python-quickstart
+
+## Rust
+
+### [Nix + Rust Quickstart][nix-rust-quickstart]
+
+A [`cargo-generate`][cargo-generate] project template for use with Flakes,
+[`direnv`][direnv], and [`nix-direnv`][nix-direnv]. Generated projects are
+fully-featured but not tailored for any specific use-case, including things such
+as a development environment, a package expression, and continuous integration
+tooling.
+
+[nix-rust-quickstart]: https://or.computer.surgery/charles/nix-rust-quickstart
+
 <!-- General links -->
 
+[cargo-generate]: https://cargo-generate.github.io/cargo-generate/
 [devenv]: https://devenv.sh
+[direnv]: https://direnv.net/
+[nix-direnv]: https://github.com/nix-community/nix-direnv


### PR DESCRIPTION
Alternative to https://github.com/NixOS/nix.dev/pull/404 in the spirit of https://github.com/NixOS/nix.dev/pull/404#issuecomment-1335090971. Primarily motivated by [this message][0] and [this message][1] in [#nix:nixos.org](https://matrix.to/#/#nix:nixos.org). I'm not sure whether this is the right place to put this kind of thing, but I suppose I'll find out by posting this PR :sweat_smile:

I've been maintaining these two project templates for quite a while with what I believe are best practices for both the ecosystem each is for and their integration with Nix. It took a considerable amount of time (and is still ongoing) to gain the necessary experience, read the relevant documentation, and discern the current ecosystem direction to reach the point these are currently at[^1].

I've allegedly saved a handful of people a substantial amount of headache by having these available for use/reference, so increasing their discoverability will likely be very helpful for others. I hadn't considered trying to document these templates anywhere myself before since that kinda feels like self advertising, but the messages linked above suggest some actual desire from others for this to happen, so here we are.

[0]: https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$CiHJLK8NGecC7Lrml10anZeQTUF2MjIPv-TM3Sk0zh4?via=nixos.org&via=matrix.org&via=tchncs.de
[1]: https://matrix.to/#/!KqkRjyTEzAGRiZFBYT:nixos.org/$k2JVzNaw3veTUGRJurTDFd1MKx7n2p4OeFZzrbvxqoc?via=nixos.org&via=matrix.org&via=tchncs.de

[^1]: Especially for Python...