### PR TITLE
Remove mention of corporate sponsors

### DIFF
--- a/source/_templates/acknowledgments.html
+++ b/source/_templates/acknowledgments.html
@@ -1,0 +1,9 @@
+<div class="caption" role="heading">
+  <span class="caption-text">Acknowledgments</span>
+</div>
+<div>
+    <a href="https://cachix.org">Cachix</a>
+</div>
+<div>
+    <a href="https://tweag.io">Tweag</a>
+</div>

--- a/source/_templates/acknowledgments.html
+++ b/source/_templates/acknowledgments.html
@@ -1,9 +1,0 @@
-<div class="caption" role="heading">
-  <span class="caption-text">Acknowledgments</span>
-</div>
-<div>
-    <a href="https://cachix.org">Cachix</a>
-</div>
-<div>
-    <a href="https://tweag.io">Tweag</a>
-</div>

--- a/source/_templates/sponsors.html
+++ b/source/_templates/sponsors.html
@@ -1,0 +1,3 @@
+<dt>Sponsored by</dt>
+<dd><a href="https://cachix.org">Cachix - binary cache hosting</a></dd>
+<dd><a href="https://tweag.io">Tweag</a></dd>

--- a/source/_templates/sponsors.html
+++ b/source/_templates/sponsors.html
@@ -1,3 +1,0 @@
-<dt>Sponsored by</dt>
-<dd><a href="https://cachix.org">Cachix - binary cache hosting</a></dd>
-<dd><a href="https://tweag.io">Tweag</a></dd>

--- a/source/acknowledgments/sponsors.md
+++ b/source/acknowledgments/sponsors.md
@@ -1,4 +1,6 @@
 # Sponsors
 
+The following companies have contributed to make this effort possible:
+
 * [Cachix](https://cachix.org) - binary cache hosting
 * [Tweag](https://tweag.io)

--- a/source/acknowledgments/sponsors.md
+++ b/source/acknowledgments/sponsors.md
@@ -5,5 +5,4 @@ The following companies have contributed to make this effort possible:
 * [Cachix](https://cachix.org) - binary cache hosting
 * [Tweag](https://tweag.io)
 
-You can support the Nix documentation project via our
-[OpenCollective](https://opencollective.com/nixos/projects/documentation-project).
+You can support the Nix documentation project via [Open Collective](https://opencollective.com/nixos/projects/documentation-project).

--- a/source/acknowledgments/sponsors.md
+++ b/source/acknowledgments/sponsors.md
@@ -1,0 +1,4 @@
+# Sponsors
+
+* [Cachix](https://cachix.io) - binary cache hosting
+* [Tweag](https://tweag.io)

--- a/source/acknowledgments/sponsors.md
+++ b/source/acknowledgments/sponsors.md
@@ -1,4 +1,4 @@
 # Sponsors
 
-* [Cachix](https://cachix.io) - binary cache hosting
+* [Cachix](https://cachix.org) - binary cache hosting
 * [Tweag](https://tweag.io)

--- a/source/acknowledgments/sponsors.md
+++ b/source/acknowledgments/sponsors.md
@@ -4,3 +4,6 @@ The following companies have contributed to make this effort possible:
 
 * [Cachix](https://cachix.org) - binary cache hosting
 * [Tweag](https://tweag.io)
+
+You can support the Nix documentation project via our
+[OpenCollective](https://opencollective.com/nixos/projects/documentation-project).

--- a/source/conf.py
+++ b/source/conf.py
@@ -192,7 +192,6 @@ html_sidebars = {
         "search-field.html",
         "sbt-sidebar-nav.html",
         "subscribe.html",
-        "acknowledgments.html",
     ],
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -192,6 +192,7 @@ html_sidebars = {
         "search-field.html",
         "sbt-sidebar-nav.html",
         "subscribe.html",
+        "sponsors.html",
     ],
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "nix.dev"
-author = "nix.dev contributors"
+author = "the nix.dev contributors, with support from our <a href='acknowledgments/sponsors.html'>sponsors</a>."
 copyright = "2016-" + str(date.today().year) + ", NixOS Foundation"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/conf.py
+++ b/source/conf.py
@@ -192,7 +192,6 @@ html_sidebars = {
         "search-field.html",
         "sbt-sidebar-nav.html",
         "subscribe.html",
-        "sponsors.html",
     ],
 }
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -75,7 +75,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "nix.dev"
-author = "the nix.dev contributors, with support from our <a href='acknowledgments/sponsors.html'>sponsors</a>."
+author = "the nix.dev contributors."
 copyright = "2016-" + str(date.today().year) + ", NixOS Foundation"
 
 # The version info for the project you're documenting, acts as replacement for

--- a/source/conf.py
+++ b/source/conf.py
@@ -192,7 +192,7 @@ html_sidebars = {
         "search-field.html",
         "sbt-sidebar-nav.html",
         "subscribe.html",
-        "sponsors.html",
+        "acknowledgments.html",
     ],
 }
 

--- a/source/index.md
+++ b/source/index.md
@@ -78,3 +78,12 @@ contributing/how-to-get-help.md
 contributing/documentation.md
 contributing/writing-a-tutorial.md
 ```
+
+```{toctree}
+:glob:
+:caption: Acknowledgments
+:maxdepth: 1
+:hidden:
+
+acknowledgments/sponsors.md
+```


### PR DESCRIPTION
Now that the site is owned by the foundation.