### PR TITLE
Remove "reproducible" from glossary

### DIFF
--- a/source/reference/glossary.md
+++ b/source/reference/glossary.md
@@ -24,8 +24,4 @@ NixOS
     Linux distribution based on Nix and Nixpkgs.
 
     Read /nɪks oʊ ɛs/ ("Niks Oh Es").
-
-reproducible
-    Reproducibility would guarantee exactly the same results no matter
-    **when** or **on what machine** you run the command.
 ```


### PR DESCRIPTION
It is not part of the official terminology the nixos documentation team established in https://github.com/NixOS/nix.dev/pull/263.

It was mixed in https://github.com/NixOS/nix.dev/pull/380 and messed up the official status of the terms. This change fixes that!

It can be added again when we figured out what we mean by it (https://github.com/NixOS/nix.dev/issues/464).

@fricklerhandwerk 