### PR TITLE
tutorials/first-steps/nix-language: Fix the nixpkgs example

### DIFF
--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -2052,8 +2052,6 @@ Explanation:
   `fetchurl` itself comes from the outer function's arguments.
 - The `meta` attribute is itself an attribute set, where the `license` attribute has the value that was assigned to the nested attribute `lib.licenses.gpl3Plus`.
 
-The package can be built by running `nix-build -E 'with import <nixpkgs> {}; callPackage ./hello.nix {}'`.
-
 ## References
 
 - [Nix manual: Nix language][manual-language]

--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -2048,7 +2048,8 @@ Explanation:
 
 - This expression is a function that takes an attribute set which must have exactly the attributes `lib`, `stdenv`, and `fetchurl`.
 - It returns the result of evaluating the function `mkDerivation`, which is an attribute of `stdenv`, applied to a recursive set.
-- The recursive set passed to `mkDerivation` uses its own `pname` and `version` attributes in the argument to the function `fetchurl`, which is an attribute of the argument attribute set.
+- The recursive set passed to `mkDerivation` uses its own `pname` and `version` attributes in the argument to the function `fetchurl`.
+  `fetchurl` itself comes from the outer function's arguments.
 - The `meta` attribute is itself an attribute set, where the `license` attribute has the value that was assigned to the nested attribute `lib.licenses.gpl3Plus`.
 
 The package can be built by running `nix-build -E 'with import <nixpkgs> {}; callPackage ./hello.nix {}'`.

--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -2022,7 +2022,7 @@ Explanation:
 ### Package
 
 ```{code-block} nix
-{ lib, stdenv }:
+{ lib, stdenv, fetchurl }:
 
 stdenv.mkDerivation rec {
 
@@ -2030,7 +2030,7 @@ stdenv.mkDerivation rec {
 
   version = "2.12";
 
-  src = builtins.fetchTarball {
+  src = fetchurl {
     url = "mirror://gnu/${pname}/${pname}-${version}.tar.gz";
     sha256 = "1ayhp9v4m4rdhjmnl2bq3cibrbqqkgjbl3s7yk2nhlh8vj3ay16g";
   };
@@ -2046,10 +2046,12 @@ This example is a (simplified) package declaration from Nixpkgs.
 
 Explanation:
 
-- This expression is a function that takes an attribute set which must have exactly the attributes `lib` and `stdenv`.
+- This expression is a function that takes an attribute set which must have exactly the attributes `lib`, `stdenv`, and `fetchurl`.
 - It returns the result of evaluating the function `mkDerivation`, which is an attribute of `stdenv`, applied to a recursive set.
-- The recursive set passed to `mkDerivation` uses its own `pname` and `version` attributes in the argument to the built-in function `fetchTarball`.
+- The recursive set passed to `mkDerivation` uses its own `pname` and `version` attributes in the argument to the function `fetchurl`, which is an attribute of the argument attribute set.
 - The `meta` attribute is itself an attribute set, where the `license` attribute has the value that was assigned to the nested attribute `lib.licenses.gpl3Plus`.
+
+The package can be built by running `nix-build -E 'with import <nixpkgs> {}; callPackage ./hello.nix {}'`.
 
 ## References
 


### PR DESCRIPTION
The example didn't build for me, and on the Matrix room, it was pointed out that `fetchTarball` doesn't work with `mirror://`.

I fixed the code to build, and tried to update the explanation to match.

I also added a command which builds the package.