### PR TITLE
Ignore linkcheck on GitHub file viewer/browser

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -416,7 +416,10 @@ linkcheck_ignore = [
     # returns 403 on CI
     r"https://www.lesswrong.com",
     # Linkcheck fails on anchors in GH READMEs, see https://github.com/sphinx-doc/sphinx/issues/9016
-    r"https://github.com/cachix/install-nix-action#how-do-i-run-nixos-tests"
+    r"https://github.com/cachix/install-nix-action#how-do-i-run-nixos-tests",
+    # Linkcheck fails on anchors in GH browser/file viewer, see https://github.com/sphinx-doc/sphinx/issues/11484
+    r"https://github\.com/.+/.+/blob/.*#.*$",
+    r"https://github\.com/.+/.+/tree/.*#.*$",
 ]
 
 # Anchors are not present in HTML


### PR DESCRIPTION
This is done in order to unbreak CI until a proper solution is found.

Related to https://github.com/NixOS/nix.dev/issues/631