### PR TITLE
fix broken bob build link

### DIFF
--- a/source/influences.md
+++ b/source/influences.md
@@ -4,4 +4,4 @@
 - https://www.habitat.sh/
 - https://www.gnu.org/software/guix/
 - https://github.com/andrewchambers/hermes
-- https://bob.build/
+- https://bobbuildtool.dev/


### PR DESCRIPTION
[CI is failing on the linkchecker](https://github.com/NixOS/nix.dev/actions/runs/5501183704/jobs/10024586676#step:6:141) because https://bob.build returns a 502 bad gateway error.

The new project site is at https://bobbuildtool.dev.