### PR TITLE
correct dd command, removing .zst from if=*.img.zst

### DIFF
--- a/source/tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
+++ b/source/tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
@@ -53,7 +53,7 @@ Press `ctrl-c` to stop `dmesg --follow`.
 Copy NixOS to your SD card by replacing `sdX` with the name of your device in the following command:
 
 ```console
-[nix-shell:~]$ sudo dd if=nixos-sd-image-23.11pre500597.0fbe93c5a7c-aarch64-linux.img.zst of=/dev/sdX bs=4096 conv=fsync status=progress
+[nix-shell:~]$ sudo dd if=nixos-sd-image-23.11pre500597.0fbe93c5a7c-aarch64-linux.img of=/dev/sdX bs=4096 conv=fsync status=progress
 ```
 
 Once that command exits, **move the SD card into your Raspberry Pi and power it on**.


### PR DESCRIPTION
the command to image the SD card included `if=nixos-sd-image-......img.zst` though the intention here is to write the non-compressed image to the SD, not the compressed zst image.

.img.zst > .img

As written this command would not function as intended.