### PR TITLE
Update nix-language.md

### DIFF
--- a/source/tutorials/first-steps/nix-language.md
+++ b/source/tutorials/first-steps/nix-language.md
@@ -1687,7 +1687,7 @@ pkgs.lib.strings.removePrefix "no " "no true scotsman"
 To make this function produce a result, you can write it to a file (e.g. `file.nix`) and pass it an argument through `nix-instantiate`:
 
 ```shell-session
-$ nix-instantiate --eval test.nix --arg pkgs 'import <nixpkgs> {}'
+$ nix-instantiate --eval file.nix --arg pkgs 'import <nixpkgs> {}'
 "true scotsman"
 ```
 


### PR DESCRIPTION
description example: (e.g. `file.nix`)

is different from code example: `nix-instantiate --eval test.nix --arg pkgs 'import <nixpkgs> {}'`

this is not consistent with the rest of the document and the change should avoid some minor mistakes