### PR TITLE
Fix minor wording error

### DIFF
--- a/source/tutorials/first-steps/ad-hoc-shell-environments.md
+++ b/source/tutorials/first-steps/ad-hoc-shell-environments.md
@@ -41,7 +41,7 @@ Within the Nix shell, you can use the programs provided by these packages:
 [nix-shell:~]$ cowsay Hello, Nix! | lolcat
 ```
 
-Press type `exit` or press `CTRL-D` to exit the shell, and the programs won't be available anymore.
+Type `exit` or press `CTRL-D` to exit the shell, and the programs won't be available anymore.
 
 ```shell-session
 [nix-shell:~]$ exit


### PR DESCRIPTION
This minor wording error is found in the section titled, "**Create a shell environment**", where the verbs "Press" and "type" are adjacent to each other.  The proposed fix removes the "Press" verb altogether.