### PR TITLE
Add line numbers to Nix, Python code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ As you make changes your browser should auto-reload within a few seconds.
 
 For contents and style see [contribution guide](CONTRIBUTING.md).
 
-For syntax see [RST/Sphinx Cheatsheet](https://sphinx-tutorial.readthedocs.io/cheatsheet/).
+Content is written in MyST, a superset of CommonMark. For its syntax, see the [MyST docs](https://myst-parser.readthedocs.io/en/latest/syntax/typography.html#syntax-core).

--- a/source/conf.py
+++ b/source/conf.py
@@ -57,6 +57,7 @@ myst_enable_extensions = [
 # GitHub-style automatic anchors for headings
 myst_heading_anchors = 3
 
+myst_number_code_blocks = [ "nix", "python" ]
 
 copybutton_prompt_text = r"# |\$ "
 copybutton_prompt_is_regexp = True


### PR DESCRIPTION
These could also be referenced in an article's prose.

For an example, see https://line-nos.nix-dot-dev.pages.dev/tutorials/learning-journey/packaging-existing-software#a-new-command