### PR TITLE
`CODEOWNERS`: remove domenkozar, fricklerhandwerk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,44 +11,8 @@
 # This also holds true for GitHub teams. Since almost none of our teams have write
 # permissions, you need to list all members of the team with commit access individually.
 
-# This file
-.github/CODEOWNERS @domenkozar
+* @NixOS/documentation-team
 
-# Dependabot
-.github/dependabot.yml @domenkozar
-
-# GitHub Actions
-.github/workflows/ @domenkozar
-
-# Meta-documentation
-CONTRIBUTING.md @domenkozar
-LICENSE.md @domenkozar
-README.md @domenkozar @fricklerhandwerk
-cla/ @domenkozar
-
-# GitPod
-.gitpod* @domenkozar
-
-# gitignore
-.gitignore @domenkozar
-
-# Nix machinery
-*.nix @domenkozar
-flake.lock @domenkozar
-
-# Python machinery
-poetry.lock @domenkozar
-pyproject.toml @domenkozar
-
-# Build and run machinery
-Makefile @domenkozar
-live* @domenkozar
-runtime.txt @domenkozar
-run_code_block_tests.sh @domenkozar
-.imgbogconfig @domenkozar
-
-# Documentation sources
-source/ @domenkozar @fricklerhandwerk
-
-# Working group docs
-maintainers/working_groups/learning_journey/ @zmitchell
+# Learning Journey
+maintainers/working_groups/learning_journey/ @NixOS/learning-journey-working-group @NixOS/documentation-team
+source/tutorials/learning_journey/ @NixOS/learning-journey-working-group @NixOS/documentation-team


### PR DESCRIPTION
The reasoning is:
- domenkozar has transferred ownership of the infrastructure #481
- unless someone is a team lead on a specific sub-team (as is the case for zmitchell), we (people with write access to nix.dev) should all be able to merge PRs