### PR TITLE
remove regex that breaks copy button

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -59,7 +59,7 @@ myst_heading_anchors = 3
 
 myst_number_code_blocks = [ "nix", "python" ]
 
-copybutton_prompt_text = r"# |\$ "
+copybutton_prompt_text = r"\$ "
 copybutton_prompt_is_regexp = True
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
Fixes #688

## Problem
The bug preventing copying the full block text is due to this regular expression in `conf.py`:

```python
copybutton_prompt_text = r"# |\$ "
```

which [does the following](https://sphinx-copybutton.readthedocs.io/en/latest/use.html#strip-and-configure-input-prompts-for-code-cells):
- removes the prompt from the beginning of any lines that start with it, and
- copies **only** the lines that contain the prompt(s), if they are found, or otherwise copies the full contents of the code block.

The current regex matches on the user and root shell prompts, so presumably this was originally meant to capture text from `console` or `shell-session` blocks, but actually results in the copy button ignoring **any** useful text in blocks that contain a comment (except for the comment text).

## Investigating
I checked the directory for instances where we use a leading `#` character after opening a codeblock and found only these two files:

```shell-session
$ rg -U '^```.*\n#\s{1}+'                                                                                              [19:40:15]
tutorials/learning-journey/packaging-existing-software.md
66:```nix
67:# hello.nix
108:```nix
109:# default.nix
149:```nix
150:# hello.nix
211:```nix
212:# default.nix
224:```nix
225:# icat.nix
243:```nix
244:# icat.nix
284:```nix
285:# icat.nix
334:```nix
335:# icat.nix
391:```nix
392:# icat.nix
455:```nix
456:# icat.nix
500:```nix
501:# icat.nix

tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
77:```shell-session
78:# wpa_supplicant -B -i wlan0 -c <(wpa_passphrase 'SSID' 'passphrase') &
89:```shell-session
90:# nix-shell -p raspberrypi-eeprom
159:```shell-session
160:# curl -L https://tinyurl.com/tutorial-nixos-install-rpi4 > /etc/nixos/configuration.nix
171:```shell-session
172:# nixos-rebuild boot
```

Every instance in `packaging-existing-software.md` is a comment containing a filename, which doesn't break anything. In `installing-nixos-on-a-raspberry-pi.md`, we have several instances of the root prompt, including several commands run as root in the same codeblock, but nobody reading that tutorial will ever be using the copy button and pasting what they get into a console (I *hope*), so it should be fine to copy the `#` in those cases, or the whole block in places where there are several commands, like [here](https://nix.dev/tutorials/nixos/installing-nixos-on-a-raspberry-pi#updating-firmware).

## The Fix
Remove the root prompt from the regex:
```diff
- copybutton_prompt_text = r"# |\$ "
+ copybutton_prompt_text = r"\$ "
```