### PR TITLE
Use bold instead of monospace for emphasis

### DIFF
--- a/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
@@ -13,7 +13,7 @@ In various Nix examples, you'll often see references to [\<nixpkgs>](https://git
 
 This is a **convenient** way to quickly demonstrate a Nix expression and get it working by importing Nix packages.
 
-However, <ref-search-path>`the resulting Nix expression is not fully reproducible`.
+However, <ref-search-path>**the resulting Nix expression is not fully reproducible**.
 
 ## Pinning packages with URLs inside a Nix expression
 


### PR DESCRIPTION
It appears that in the `towards-reproducibility-pinning-nixpkgs.md` page, the monospace code formatting is used for emphasis.  This is not the intended use of this formatting, and the rest of the page uses bold for emphasis.