### PR TITLE
move 'What to do if a binary...?' from FAQs to Troubleshooting

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -33,7 +33,7 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 
 ### What to do if a binary cache is down or unreachable?
 
-Pass `--option substitute false` to Nix commands.
+Pass `--option substitute false` to Nix commands. 
 
 ### How do I add a new binary cache?
 


### PR DESCRIPTION
Initiating pull request to move:

- [What to do if a binary cache is down or unreachable?](https://nix.dev/recipes/faq#what-to-do-if-a-binary-cache-is-down-or-unreachable)

to `nix.dev/recipes/troubleshooting/`. Being Troubleshooting a new category within Recipes.