### PR TITLE
move 'How do I add a new binary...?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -37,7 +37,7 @@ Pass `--option substitute false` to Nix commands.
 
 ### How do I add a new binary cache?
 
-Using NixOS (≥ 22.05):
+Using NixOS (≥ 22.05): 
 
 ```nix
 nix.settings = {


### PR DESCRIPTION
Initiating pull request to move:

- [How do I add a new binary cache?](https://nix.dev/recipes/faq#how-do-i-add-a-new-binary-cache)

to `nix.dev/recipes/`.