### PR TITLE
move 'How do I force nix to re-check...?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -66,7 +66,7 @@ $ nix-build helpers/bench.nix --option extra-binary-caches https://cache.nixos.o
 
 Nix caches the contents of binary caches so that it doesn't have to query them
 on every command. This includes negative answers (cache doesn't have something).
-The default timeout for that is 1 hour as of writing.
+The default timeout for that is 1 hour as of writing. 
 
 To wipe all cache-lookup-caches:
 


### PR DESCRIPTION
Initiating pull request to move:

- [How do I force Nix to re-check whether something exists at a binary cache?](https://nix.dev/recipes/faq#how-do-i-force-nix-to-re-check-whether-something-exists-at-a-binary-cache)

to `nix.dev/recipes/`.