### PR TITLE
move 'How do I fix: error: querying p...?' from FAQs to Troubleshooting

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -79,7 +79,7 @@ cache timeout.
 
 ### How do I fix: error: querying path in database: database disk image is malformed
 
-Try:
+Try: 
 
 ```shell-session
 $ sqlite3 /nix/var/nix/db/db.sqlite "pragma integrity_check"


### PR DESCRIPTION
Initiating pull request to move:

- [How do I fix: error: querying path in database: database disk image is malformed](https://nix.dev/recipes/faq#how-do-i-fix-error-querying-path-in-database-database-disk-image-is-malformed)

to `nix.dev/recipes/troubleshooting/`. Being Troubleshooting a new category within Recipes.