### PR TITLE
move 'How to operate between Nix paths...?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -93,7 +93,7 @@ $ mv /nix/var/nix/db/db.sqlite /nix/var/nix/db/db.sqlite-bkp
 $ sqlite3 /nix/var/nix/db/db.sqlite-bkp ".dump" | sqlite3 /nix/var/nix/db/db.sqlite
 ```
 
-### How to operate between Nix paths and strings?
+### How to operate between Nix paths and strings? 
 
 See <http://stackoverflow.com/a/43850372>
 


### PR DESCRIPTION
Initiating pull request to move:

- [How to operate between Nix paths and strings?](https://nix.dev/recipes/faq#how-to-operate-between-nix-paths-and-strings)

to `nix.dev/recipes/`.