### PR TITLE
move 'How do I fix: error: current Nix store...?' from FAQs to Troubleshooting

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -100,7 +100,7 @@ See <http://stackoverflow.com/a/43850372>
 ### How do I fix: error: current Nix store schema is version 10, but I only support 7
 
 This means you have upgraded Nix sqlite schema to a newer version, but then tried
-to use older Nix.
+to use older Nix. 
 
 The solution is to dump the db and use old Nix version to initialize it:
 


### PR DESCRIPTION
Initiating pull request to move:

- [How do I fix: error: current Nix store schema is version 10, but I only support 7](https://nix.dev/recipes/faq#how-do-i-fix-error-current-nix-store-schema-is-version-10-but-i-only-support-7)

to `nix.dev/recipes/troubleshooting/`. Being Troubleshooting a new category within Recipes.