### PR TITLE
move 'How to build reverse dependencies...?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -112,7 +112,7 @@ $ nix-store --init # this is the old nix-store
 $ nix-store --load-db < /tmp/db.dump
 ```
 
-### How to build reverse dependencies of a package?
+### How to build reverse dependencies of a package? 
 
 ```shell-session
 $ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"


### PR DESCRIPTION
Initiating pull request to move:

- [How to build reverse dependencies of a package?](https://nix.dev/recipes/faq#how-to-build-reverse-dependencies-of-a-package)

to `nix.dev/recipes/`.