### PR TITLE
move 'I’m getting: writing to file: Connec...?' from FAQs to Troubleshooting

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -120,7 +120,7 @@ $ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
 
 ### I'm getting: writing to file: Connection reset by peer
 
-Too big files in src, out of resources (HDD space, memory)
+Too big files in src, out of resources (HDD space, memory).
 
 ### What are channels and different branches on github?
 


### PR DESCRIPTION
Initiating pull request to move:

- [I’m getting: writing to file: Connection reset by peer](https://nix.dev/recipes/faq#i-m-getting-writing-to-file-connection-reset-by-peer)

to `nix.dev/recipes/troubleshooting/`. Being Troubleshooting a new category within Recipes.