### PR TITLE
move 'What are channels and different...?' from FAQs to Concepts

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -124,7 +124,7 @@ Too big files in src, out of resources (HDD space, memory)
 
 ### What are channels and different branches on github?
 
-See <https://nixos.wiki/wiki/Nix_channels>
+See <https://nixos.wiki/wiki/Nix_channels> 
 
 ### How can I manage dotfiles in \$HOME with Nix?
 


### PR DESCRIPTION
Initiating pull request to move:

- [What are channels and different branches on github?](https://nix.dev/recipes/faq#what-are-channels-and-different-branches-on-github)

to `https://nix.dev/concepts/`.