### PR TITLE
move 'How can I manage dotfiles in $HOME with Nix?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -128,7 +128,7 @@ See <https://nixos.wiki/wiki/Nix_channels>
 
 ### How can I manage dotfiles in \$HOME with Nix?
 
-See <https://github.com/nix-community/home-manager>
+See <https://github.com/nix-community/home-manager> 
 
 ### Are there some known impurities in builds?
 


### PR DESCRIPTION
Initiating pull request to move:

- [How can I manage dotfiles in $HOME with Nix?](https://nix.dev/recipes/faq#how-can-i-manage-dotfiles-in-home-with-nix)

to `nix.dev/recipes/`.