### PR TITLE
move 'Are there some known impurities in builds?' from FAQs to Concepts

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -132,7 +132,7 @@ See <https://github.com/nix-community/home-manager>
 
 ### Are there some known impurities in builds?
 
-Yes.
+Yes. 
 
 - CPU (we try hard to avoid compiling native instructions, but rather hardcode supported ones)
 - current time/date


### PR DESCRIPTION
Initiating pull request to move:

- [Are there some known impurities in builds?](https://nix.dev/recipes/faq#are-there-some-known-impurities-in-builds)

to `https://nix.dev/concepts/`.