### PR TITLE
move 'What’s the recommended process for building...?' from FAQs to Recipes

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -142,7 +142,7 @@ Yes.
 
 ### What's the recommended process for building custom packages?
 
-> E.g. if I git clone nixpkgs how do I use the cloned repo to define new / updated packages?
+> E.g. if I git clone nixpkgs how do I use the cloned repo to define new / updated packages? 
 
 ## NixOS
 


### PR DESCRIPTION
Initiating pull request to move:

- [What’s the recommended process for building custom packages?](https://nix.dev/recipes/faq#what-s-the-recommended-process-for-building-custom-packages) = "How to build a custom package?" – doesn't have a proper response

to `nix.dev/recipes/`.