### PR TITLE
added new category 'troubleshooting' and moved 4 faqs to it

### DIFF
--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -31,10 +31,6 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   Using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
 
-### What to do if a binary cache is down or unreachable?
-
-Pass `--option substitute false` to Nix commands.
-
 ### How do I add a new binary cache?
 
 Using NixOS (≥ 22.05):
@@ -77,50 +73,15 @@ $ rm $HOME/.cache/nix/binary-cache-v*.sqlite*
 Alternatively, use the `narinfo-cache-negative-ttl` option to reduce the
 cache timeout.
 
-### How do I fix: error: querying path in database: database disk image is malformed
-
-Try:
-
-```shell-session
-$ sqlite3 /nix/var/nix/db/db.sqlite "pragma integrity_check"
-```
-
-Which will print the errors in the database. If the errors are due to missing
-references, the following may work:
-
-```shell-session
-$ mv /nix/var/nix/db/db.sqlite /nix/var/nix/db/db.sqlite-bkp
-$ sqlite3 /nix/var/nix/db/db.sqlite-bkp ".dump" | sqlite3 /nix/var/nix/db/db.sqlite
-```
-
 ### How to operate between Nix paths and strings?
 
 See <http://stackoverflow.com/a/43850372>
-
-### How do I fix: error: current Nix store schema is version 10, but I only support 7
-
-This means you have upgraded Nix sqlite schema to a newer version, but then tried
-to use older Nix.
-
-The solution is to dump the db and use old Nix version to initialize it:
-
-```shell-session
-$ /path/to/nix/unstable/bin/nix-store --dump-db > /tmp/db.dump
-$ mv /nix/var/nix/db /nix/var/nix/db.toonew
-$ mkdir /nix/var/nix/db
-$ nix-store --init # this is the old nix-store
-$ nix-store --load-db < /tmp/db.dump
-```
 
 ### How to build reverse dependencies of a package?
 
 ```shell-session
 $ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
 ```
-
-### I'm getting: writing to file: Connection reset by peer
-
-Too big files in src, out of resources (HDD space, memory)
 
 ### What are channels and different branches on github?
 

--- a/source/recipes/index.md
+++ b/source/recipes/index.md
@@ -7,6 +7,8 @@ These sections contains guides to getting things done.
 :glob:
 :maxdepth: 2
 
-*
+./best-practices.md
+./faq.md
 ../templates/*
+./troubleshooting.md
 ```

--- a/source/recipes/troubleshooting.md
+++ b/source/recipes/troubleshooting.md
@@ -1,0 +1,40 @@
+# Troubleshooting
+
+## What to do if a binary cache is down or unreachable?
+
+Pass `--option substitute false` to Nix commands.
+
+### How do I fix: error: querying path in database: database disk image is malformed
+
+Try:
+
+```shell-session
+$ sqlite3 /nix/var/nix/db/db.sqlite "pragma integrity_check"
+```
+
+Which will print the errors in the database. If the errors are due to missing
+references, the following may work:
+
+```shell-session
+$ mv /nix/var/nix/db/db.sqlite /nix/var/nix/db/db.sqlite-bkp
+$ sqlite3 /nix/var/nix/db/db.sqlite-bkp ".dump" | sqlite3 /nix/var/nix/db/db.sqlite
+```
+
+### How do I fix: error: current Nix store schema is version 10, but I only support 7
+
+This means you have upgraded Nix sqlite schema to a newer version, but then tried
+to use older Nix.
+
+The solution is to dump the db and use old Nix version to initialize it:
+
+```shell-session
+$ /path/to/nix/unstable/bin/nix-store --dump-db > /tmp/db.dump
+$ mv /nix/var/nix/db /nix/var/nix/db.toonew
+$ mkdir /nix/var/nix/db
+$ nix-store --init # this is the old nix-store
+$ nix-store --load-db < /tmp/db.dump
+```
+
+### I'm getting: writing to file: Connection reset by peer
+
+Too big files in src, out of resources (HDD space, memory)

--- a/source/recipes/troubleshooting.md
+++ b/source/recipes/troubleshooting.md
@@ -2,30 +2,32 @@
 
 ## What to do if a binary cache is down or unreachable?
 
-Pass `--option substitute false` to Nix commands.
+Pass [`--option substitute false`](https://nixos.org/manual/nix/stable/command-ref/conf-file#conf-substitute) to Nix commands.
 
-### How do I fix: error: querying path in database: database disk image is malformed
+### How to fix: `error: querying path in database: database disk image is malformed`
 
+This is a [known issue](https://github.com/NixOS/nix/issues/1353).
 Try:
 
 ```shell-session
 $ sqlite3 /nix/var/nix/db/db.sqlite "pragma integrity_check"
 ```
 
-Which will print the errors in the database. If the errors are due to missing
-references, the following may work:
+Which will print the errors in the [database](https://nixos.org/manual/nix/stable/glossary#gloss-nix-database).
+If the errors are due to missing references, the following may work:
 
 ```shell-session
 $ mv /nix/var/nix/db/db.sqlite /nix/var/nix/db/db.sqlite-bkp
 $ sqlite3 /nix/var/nix/db/db.sqlite-bkp ".dump" | sqlite3 /nix/var/nix/db/db.sqlite
 ```
 
-### How do I fix: error: current Nix store schema is version 10, but I only support 7
+### How to fix: `error: current Nix store schema is version 10, but I only support 7`
 
-This means you have upgraded Nix sqlite schema to a newer version, but then tried
-to use older Nix.
+This is a [known issue](https://github.com/NixOS/nix/issues/1251).
 
-The solution is to dump the db and use old Nix version to initialize it:
+It means that using a new version of Nix upgraded the SQLite schema of the [database](https://nixos.org/manual/nix/stable/glossary#gloss-nix-database), and then you tried to use an older version Nix.
+
+The solution is to dump the database, use the old Nix version to initialize it, and then re-import the data:
 
 ```shell-session
 $ /path/to/nix/unstable/bin/nix-store --dump-db > /tmp/db.dump
@@ -35,6 +37,8 @@ $ nix-store --init # this is the old nix-store
 $ nix-store --load-db < /tmp/db.dump
 ```
 
-### I'm getting: writing to file: Connection reset by peer
+### How to fix: `writing to file: Connection reset by peer`
 
-Too big files in src, out of resources (HDD space, memory)
+This may mean you are trying to import a too large file or directory into the [Nix store](https://nixos.org/manual/nix/stable/glossary#gloss-store), or your machine is running out of resources, such as disk space or memory.
+
+Try to reduce the size of the directory to import, or run [garbage collection](https://nixos.org/manual/nix/stable/command-ref/nix-collect-garbage).


### PR DESCRIPTION
Moved contents of:

[What to do if a binary cache is down or unreachable?](https://nix.dev/recipes/faq#what-to-do-if-a-binary-cache-is-down-or-unreachable)
[How do I fix: error: querying path in database: database disk image is malformed](https://nix.dev/recipes/faq#how-do-i-fix-error-querying-path-in-database-database-disk-image-is-malformed)
[How do I fix: error: current Nix store schema is version 10, but I only support 7](https://nix.dev/recipes/faq#how-do-i-fix-error-current-nix-store-schema-is-version-10-but-i-only-support-7)
[I’m getting: writing to file: Connection reset by peer](https://nix.dev/recipes/faq#i-m-getting-writing-to-file-connection-reset-by-peer)

from FAQs to a newly created category "Troubleshooting" under Recipes, as per:

- https://github.com/NixOS/nix.dev/issues/657