### PR TITLE
homepage: put link to first steps at the top.

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -9,7 +9,9 @@ myst:
 
 # Welcome to nix.dev
 
-nix.dev is the home of official documentation for the Nix ecosystem, it contains:
+nix.dev is the home of official documentation for the Nix ecosystem.
+
+If you're new to Nix, begin your journey with {ref}`First Steps <first-steps>`!
 
 ::::{grid} 2
 :::{grid-item-card} Tutorials
@@ -46,8 +48,6 @@ Collections of detailed technical descriptions
 Explanations of history and ideas in the Nix ecosystem
 :::
 ::::
-
-If you're new to the Nix ecosystem, begin your journey with {ref}`First Steps <first-steps>`!
 
 ## What can you do with Nix?
 


### PR DESCRIPTION
In my opinion, the link to the first steps should be the first thing a new user should see.

Indeed, the first actionnable thing for a new user should be to "just get started".

I think that putting any link before means that there are all sorts of "paths" proposed, instead of one clear path.

If possible, I would go further and make the call to action even more visible. Usually it is done with a button-like UI.