### PR TITLE
Remove superfluous variation of a snippet in cross compilation doc

### DIFF
--- a/source/tutorials/cross-compilation.md
+++ b/source/tutorials/cross-compilation.md
@@ -156,17 +156,7 @@ There are multiple equivalent ways to access packages targeted to the host platf
    in
    pkgs.pkgsCross.aarch64-multiplatform.hello
    ```
-  
-   or
-  
-   ```nix
-   let
-     # all packages for `aarch64-multiplatform`
-     pkgs = (import <nixpkgs> {}).pkgsCross.aarch64-multiplatform;
-   in
-   pkgs.hello
-   ```
-  
+
 2. Pass the host platform to `crossSystem` when importing `<nixpkgs>`:
 
    ```nix


### PR DESCRIPTION
Hi there,

The cross compilation documentation is showing, at some point, two variations on how to get a cross-compiled package 
out of Nixpkgs. Those two versions are strictly equivalent. The only unimportant difference is what prefix of the full attribute set paths that we want, that is `(import <nixpkgs> {}).pkgsCross.aarch64-multiplatform.hello` is factored out in the variable named `pkgs`. It's arguably not very helpful, and as a reader I even found it a bit confusing, because of the nesting with the original numbered list (1., 2., etc.). Because there was an `or` there, I somehow wondered if the outer numbered list had to be considered as `and`s (the text above the list answers this question, so it's fine and unambiguous - my point is just that putting nested `or` like this has confused me a bit).

Of course, it's only my take - feel free to ditch otherwise.