### PR TITLE
Move faqs flakes

### DIFF
--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -4,12 +4,12 @@
 
 You have to judge for yourself based on your needs.
 
-Flakes and the `nix` command suite bring multiple improvements that are relevant for both software users and package authors:
+[Flakes](https://nix.dev/concepts/flakes) and the `nix` command suite bring multiple improvements that are relevant for both software users and package authors:
 
-- The new command line interface, together with flakes, makes dealing with existing packages significantly more convenient.
+- The new command-line interface, together with flakes, makes dealing with existing packages significantly more convenient.
 - The constraints imposed on flakes strengthen reproducibility by default, and enable various performance improvements when interacting with a large Nix package repository like {term}`Nixpkgs`.
 - Flake references allow for easier handling of version upgrades for existing packages or project dependencies.
-- The flake schema helps with composing Nix projects from multiple sources in an ordered fashion.
+- The [flake schema](https://nixos.wiki/wiki/Flakes#Flake_schema) helps with composing Nix projects from multiple sources in an orderly fashion.
 
 Other than that, and below the surface of the flake schema, Nix and the Nix language work exactly the same in both cases.
 In principle, the same level of reproducibility can be achieved with or without flakes.
@@ -17,14 +17,14 @@ In particular, the process of adding software to {term}`Nixpkgs` or maintaining 
 
 Both paradigms have their own set of unique concepts and support tooling that have to be learned, with varying ease of use, implementation quality, and support status.
 At the moment, neither the stable nor the experimental interface is clearly superior to the other in all aspects.
-While flakes reduce complexity in some regards, they introduce additional concepts and you will have to learn more about the system to fully understand how it works.
+While flakes reduce complexity in some regards, they also introduce additional concepts and you will have to learn more about the system to fully understand how it works.
 
 There are downsides to relying on [experimental features](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-experimental-features) in general:
 
-- Interfaces and behavior of experimental features could still be changed by Nix developers.
+- Interfaces and behaviour of experimental features could still be changed by Nix developers.
   This may require you to adapt your code at some point in the future, which will be more effort when it has grown in complexity.
   Currently there is no agreed-upon plan or timeline for stabilising flakes.
 - The [Nix maintainer team](https://nixos.org/community/teams/nix.html) focuses on fixing bugs and regressions in stable interfaces, supporting well-understood use cases, as well as improving the internal design and overall contributor experience in order to ease future development.
-  Improvements to experimental features have low priority.
+  Improvements to experimental features have a low priority.
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
-  Using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
+  When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -1,0 +1,30 @@
+# Frequently Asked Questions
+
+## Should I enable flakes?
+
+You have to judge for yourself based on your needs.
+
+Flakes and the `nix` command suite bring multiple improvements that are relevant for both software users and package authors:
+
+- The new command line interface, together with flakes, makes dealing with existing packages significantly more convenient.
+- The constraints imposed on flakes strengthen reproducibility by default, and enable various performance improvements when interacting with a large Nix package repository like {term}`Nixpkgs`.
+- Flake references allow for easier handling of version upgrades for existing packages or project dependencies.
+- The flake schema helps with composing Nix projects from multiple sources in an ordered fashion.
+
+Other than that, and below the surface of the flake schema, Nix and the Nix language work exactly the same in both cases.
+In principle, the same level of reproducibility can be achieved with or without flakes.
+In particular, the process of adding software to {term}`Nixpkgs` or maintaining {term}`NixOS` modules and configurations is not affected by flakes at all.
+
+Both paradigms have their own set of unique concepts and support tooling that have to be learned, with varying ease of use, implementation quality, and support status.
+At the moment, neither the stable nor the experimental interface is clearly superior to the other in all aspects.
+While flakes reduce complexity in some regards, they introduce additional concepts and you will have to learn more about the system to fully understand how it works.
+
+There are downsides to relying on [experimental features](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-experimental-features) in general:
+
+- Interfaces and behavior of experimental features could still be changed by Nix developers.
+  This may require you to adapt your code at some point in the future, which will be more effort when it has grown in complexity.
+  Currently there is no agreed-upon plan or timeline for stabilising flakes.
+- The [Nix maintainer team](https://nixos.org/community/teams/nix.html) focuses on fixing bugs and regressions in stable interfaces, supporting well-understood use cases, as well as improving the internal design and overall contributor experience in order to ease future development.
+  Improvements to experimental features have low priority.
+- The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
+  Using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.

--- a/source/concepts/index.md
+++ b/source/concepts/index.md
@@ -7,5 +7,6 @@ These sections contains explanations of history and ideas in the Nix ecosystem.
 :glob:
 :maxdepth: 2
 
-*
+flakes.md
+faq.md
 ```

--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -2,35 +2,6 @@
 
 ## Nix
 
-### Should I enable flakes?
-
-You have to judge for yourself based on your needs.
-
-Flakes and the `nix` command suite bring multiple improvements that are relevant for both software users and package authors:
-
-- The new command line interface, together with flakes, makes dealing with existing packages significantly more convenient.
-- The constraints imposed on flakes strengthen reproducibility by default, and enable various performance improvements when interacting with a large Nix package repository like {term}`Nixpkgs`.
-- Flake references allow for easier handling of version upgrades for existing packages or project dependencies.
-- The flake schema helps with composing Nix projects from multiple sources in an ordered fashion.
-
-Other than that, and below the surface of the flake schema, Nix and the Nix language work exactly the same in both cases.
-In principle, the same level of reproducibility can be achieved with or without flakes.
-In particular, the process of adding software to {term}`Nixpkgs` or maintaining {term}`NixOS` modules and configurations is not affected by flakes at all.
-
-Both paradigms have their own set of unique concepts and support tooling that have to be learned, with varying ease of use, implementation quality, and support status.
-At the moment, neither the stable nor the experimental interface is clearly superior to the other in all aspects.
-While flakes reduce complexity in some regards, they introduce additional concepts and you will have to learn more about the system to fully understand how it works.
-
-There are downsides to relying on [experimental features](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-experimental-features) in general:
-
-- Interfaces and behavior of experimental features could still be changed by Nix developers.
-  This may require you to adapt your code at some point in the future, which will be more effort when it has grown in complexity.
-  Currently there is no agreed-upon plan or timeline for stabilising flakes.
-- The [Nix maintainer team](https://nixos.org/community/teams/nix.html) focuses on fixing bugs and regressions in stable interfaces, supporting well-understood use cases, as well as improving the internal design and overall contributor experience in order to ease future development.
-  Improvements to experimental features have low priority.
-- The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
-  Using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
-
 ### How do I add a new binary cache?
 
 Using NixOS (≥ 22.05):


### PR DESCRIPTION
Picked out the question:

- [Should I enable flakes?](https://nix.dev/recipes/faq#should-i-enable-flakes)

and moved it from category FAQs under recipes (subsequently to be removed) into newly created category FAQs but under concepts instead, while adding some links and some minor adjustments.