### PR TITLE
move question about channels to FAQs section

### DIFF
--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -60,6 +60,36 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
 
+## Which channel branch should I use?
+
+Nixpkgs and NixOS have both stable and rolling releases.
+
+### Stable
+
+- On Linux (including NixOS and WSL), use [`nixos-*`](https://github.com/NixOS/nixpkgs/branches/all?query=nixos-).
+
+  These branches only contain commits that passed the NixOS test suite.
+- On any other platform, use [`nixpkgs-*`](https://github.com/NixOS/nixpkgs/branches/all?query=nixpkgs-).
+
+  These branches contain commits that passed the test suites specific to other platforms.
+
+All of these "channel branches" follow the corresponding [`release-*`](https://github.com/NixOS/nixpkgs/branches/all?query=release-) branch.
+
+:::{admonition} Example
+`nixos-23.05` and `nixpkgs-23.05-darwin` are both based on `release-23.05`.
+:::
+
+### Rolling
+
+- On Linux (including NixOS and WSL), use [`nixos-unstable`](https://github.com/NixOS/nixpkgs/branches/all?query=nixos-unstable).
+- On any other platform, use [`nixpkgs-unstable`](https://github.com/NixOS/nixpkgs/branches/all?query=nixpkgs-unstable).
+
+These branches follow `master`, the main development development branch.
+
+[`*-small`](https://github.com/NixOS/nixpkgs/branches/all?query=-small) channel branches have passed a smaller test suite, which means they are more up-to-date with respect to their base branch but offer fewer stability guarantees.
+
+Consult the [`nix-channel`](https://nixos.org/manual/nix/unstable/command-ref/nix-channel) entry in the Nix Reference Manual for more information on channels, and the [Nixpkgs contributing guide](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md#branch-conventions) on the Nixpkgs branching strategy.
+
 ## Are there any impurities left in sandboxed builds?
 
 Yes. There is:

--- a/source/guides/faq.md
+++ b/source/guides/faq.md
@@ -54,10 +54,6 @@ See <http://stackoverflow.com/a/43850372>
 $ nix-shell -p nixpkgs-review --run "nixpkgs-review wip"
 ```
 
-### What are channels and different branches on github?
-
-See <https://nixos.wiki/wiki/Nix_channels>
-
 ### How can I manage dotfiles in \$HOME with Nix?
 
 See <https://github.com/nix-community/home-manager>


### PR DESCRIPTION
Moved:

- [What are channels and different branches on github?](https://nix.dev/recipes/faq#what-are-channels-and-different-branches-on-github)

from recipes/faq.md to concepts/faq.md.

However, there's way too many asumptions being made I can't just yet understand/prove. One example off the top of my fingers: "Small channels (...) update faster, but require in turn more packages to be built from source.", when comparing small channels to large ones. The update part I get, the second part, I don't.

A thorough review is needed, especially for the branch part. Also, should this branch part be a question on his own?

The answer for this question is built from the following sources:

Channels' sources:
- https://nixos.org/manual/nixos/stable/#sec-upgrading
- https://jorel.dev/NixOS4Noobs/channels#1
- https://nixos.wiki/wiki/Nix_channels
- https://discourse.nixos.org/t/differences-between-nix-channels/13998
- https://gist.github.com/grahamc/c60578c6e6928043d29a427361634df6#which-channel-is-right-for-me
- https://discourse.nixos.org/t/difference-between-channels/579

Branches' sources:
- https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
- https://nixos.wiki/wiki/FAQ#Nixpkgs_branches
- https://github.com/NixOS/nixpkgs
- https://www.reddit.com/r/NixOS/comments/s5hqet/multiple_branches_for_2111_in_nixpkgs_github/