### PR TITLE
 move question on impurities to FAQs section

### DIFF
--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -60,7 +60,7 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
 
-## Are there any known impurities in builds?
+## Are there any impurities left in sandbox builds?
 
 Yes, there are:
 

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -68,5 +68,4 @@ Yes, there are:
 - System's current time/date.
 - Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
-- Builds that access the home directory or fetch data from the Internet.
 - When random values are used, e.g., from `/dev/random` or `/dev/urandom`.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -69,4 +69,4 @@ Yes. There is:
 - The filesystem used for building (see also [`TMPDIR`](https://nixos.org/manual/nix/stable/command-ref/env-common.html#env-TMPDIR)).
 - Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
-- When random values are used, e.g., from `/dev/random` or `/dev/urandom`.
+- Insertion of random values, e.g., from `/dev/random` or `/dev/urandom`.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -60,12 +60,15 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
 
-### Are there some known impurities in builds?
+## Are there any known impurities in builds?
 
-Yes.
+Yes, there are:
 
-- CPU (we try hard to avoid compiling native instructions, but rather hardcode supported ones)
-- current time/date
-- FileSystem (ext4 has a known bug creating [empty files on power loss](https://github.com/NixOS/nixpkgs/issues/15581))
-- Kernel
-- Timing behaviour of the build system (parallel Make not getting correct inputs in some cases)
+- CPU architecture—great effort being made to avoid compilation of native instructions in favour of hardcoded supported ones.
+- System's current time/date.
+- Linux kernel parameters e.g. [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
+- Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
+- Builds that access the home directory or fetch data from the Internet.
+- When randomness is added.
+
+See [The Nix Hour #12 \[purity at eval-, build- and runtime\]](https://www.youtube.com/watch?v=96jCLfKAa5M&t=913s) for more information and examples.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -62,10 +62,11 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 
 ## Are there any impurities left in sandbox builds?
 
-Yes, there are:
+Yes. There is:
 
 - CPU architecture—great effort being made to avoid compilation of native instructions in favour of hardcoded supported ones.
 - System's current time/date.
+- The filesystem used for building (see also [`TMPDIR`](https://nixos.org/manual/nix/stable/command-ref/env-common.html#env-TMPDIR)).
 - Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
 - When random values are used, e.g., from `/dev/random` or `/dev/urandom`.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -67,7 +67,9 @@ Yes. There is:
 - CPU architecture—great effort being made to avoid compilation of native instructions in favour of hardcoded supported ones.
 - System's current time/date.
 - The filesystem used for building (see also [`TMPDIR`](https://nixos.org/manual/nix/stable/command-ref/env-common.html#env-TMPDIR)).
-- Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
+- Linux kernel parameters, such as:
+  - [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
+  - binfmt interpreters, e.g., those configured with [`boot.binfmt.emulatedSystems`](https://search.nixos.org/options?show=boot.binfmt.emulatedSystems).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
 - Insertion of random values, e.g., from `/dev/random` or `/dev/urandom`.
 - Differences between Nix versions. For instance, a new Nix version might introduce a new environment variable. A statement like `env > $out` is not promised by Nix to result in the same output, going into the future.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -66,9 +66,9 @@ Yes, there are:
 
 - CPU architecture—great effort being made to avoid compilation of native instructions in favour of hardcoded supported ones.
 - System's current time/date.
-- Linux kernel parameters e.g. [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
+- Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
 - Builds that access the home directory or fetch data from the Internet.
-- When randomness is added.
+- When random values are used, e.g., from `/dev/random` or `/dev/urandom`.
 
 See [The Nix Hour #12 \[purity at eval-, build- and runtime\]](https://www.youtube.com/watch?v=96jCLfKAa5M&t=913s) for more information and examples.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -60,7 +60,7 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
 
-## Are there any impurities left in sandbox builds?
+## Are there any impurities left in sandboxed builds?
 
 Yes. There is:
 

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -59,3 +59,13 @@ There are downsides to relying on [experimental features](https://nixos.org/manu
   Improvements to experimental features have a low priority.
 - The [Nix documentation team](https://nixos.org/community/teams/documentation.html) focuses on improving documentation and learning materials for stable features and common principles.
   When using flakes, you will have to rely more heavily on user-to-user support, third-party documentation, and the source code.
+
+### Are there some known impurities in builds?
+
+Yes.
+
+- CPU (we try hard to avoid compiling native instructions, but rather hardcode supported ones)
+- current time/date
+- FileSystem (ext4 has a known bug creating [empty files on power loss](https://github.com/NixOS/nixpkgs/issues/15581))
+- Kernel
+- Timing behaviour of the build system (parallel Make not getting correct inputs in some cases)

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -70,3 +70,4 @@ Yes. There is:
 - Linux kernel parameters, such as: [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
 - Insertion of random values, e.g., from `/dev/random` or `/dev/urandom`.
+- Differences between Nix versions. For instance, a new Nix version might introduce a new environment variable. A statement like `env > $out` is not promised by Nix to result in the same output, going into the future.

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -70,5 +70,3 @@ Yes, there are:
 - Timing behaviour of the build system—parallel Make build does not get the correct inputs in some cases.
 - Builds that access the home directory or fetch data from the Internet.
 - When random values are used, e.g., from `/dev/random` or `/dev/urandom`.
-
-See [The Nix Hour #12 \[purity at eval-, build- and runtime\]](https://www.youtube.com/watch?v=96jCLfKAa5M&t=913s) for more information and examples.

--- a/source/recipes/faq.md
+++ b/source/recipes/faq.md
@@ -62,16 +62,6 @@ See <https://nixos.wiki/wiki/Nix_channels>
 
 See <https://github.com/nix-community/home-manager>
 
-### Are there some known impurities in builds?
-
-Yes.
-
-- CPU (we try hard to avoid compiling native instructions, but rather hardcode supported ones)
-- current time/date
-- FileSystem (ext4 has a known bug creating [empty files on power loss](https://github.com/NixOS/nixpkgs/issues/15581))
-- Kernel
-- Timing behaviour of the build system (parallel Make not getting correct inputs in some cases)
-
 ### What's the recommended process for building custom packages?
 
 > E.g. if I git clone nixpkgs how do I use the cloned repo to define new / updated packages?


### PR DESCRIPTION
Moved:

- [Are there some known impurities in builds?](https://nix.dev/recipes/faq#are-there-some-known-impurities-in-builds)

from recipes/faq.md to concepts/faq.md with some minor changes/additions.

File system (ext4) bulletpoint deleted because it seems to have ended up being a different issue. See: https://github.com/snabblab/snabblab-nixos/issues/42#issuecomment-220933393
