### PR TITLE
allow rec in packaging functions

### DIFF
--- a/source/recipes/best-practices.md
+++ b/source/recipes/best-practices.md
@@ -36,6 +36,10 @@ There are a couple of pitfalls:
 - It's possible to introduce a hard to debug error `infinite recursion` when shadowing a name, the simplest example being `let b = 1; a = rec { b = b; }; in a`.
 - Combining with overriding logic such as the [`overrideAttrs`](https://nixos.org/manual/nixpkgs/stable/#sec-pkg-overrideAttrs) function in {term}`Nixpkgs` has a surprising behaviour of not overriding every reference.
 
+:::{note}
+For packaging functions not supporting `finalAttrs: { ... }`, the use of `rec` is legitimate, see [this post for details](https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293/4).
+:::
+
 :::{tip}
 Avoid `rec`. Use `let ... in`.
 


### PR DESCRIPTION
The best practice on `rec` is often interpreted in nixpkgs PRs as "rewriting `rec` using `let ... in` fixes the overriding logic", whereas it isn't the case. The second pitfall is therefore less justified.

In the [discussion about the same topic](https://discourse.nixos.org/t/avoid-rec-expresions-in-nixpkgs/8293) on Discourse, the most liked post also points out that avoiding `rec` in packaging functions doesn't make much sense.

Hence this PR.