### PR TITLE
Mention rebuilds in best practices

### DIFF
--- a/source/recipes/best-practices.md
+++ b/source/recipes/best-practices.md
@@ -216,6 +216,7 @@ The problem is that now your build is no longer reproducible, as it depends on t
 That cannot declared in the source code, and results in an impurity.
 
 If someone builds the project in a directory with a different name, they will get a different store path for `src` and everything that depends on it.
+This can be the cause of needless rebuilds both locally and in CI.
 
 :::{tip}
 Use [`builtins.path`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-path) with the `name` attribute set to something fixed.
@@ -232,4 +233,3 @@ pkgs.stdenv.mkDerivation {
 }
 ```
 :::
-


### PR DESCRIPTION
This is a small PR that adds a sentence about needless rebuilds to the "Reproducible source paths" section of the "Best Practices" page. This section currently mentions impurities, but there are actual practical concerns around using a fixed name, such as cache misses locally and in CI. Ask me how I know.