### PR TITLE
ci: fix deploy-and-build production branch filter

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -32,7 +32,7 @@ jobs:
         NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
       with:
-        production-deploy: ${{ github.event_name == 'push' && github.event.push.ref == 'refs/heads/master' }}
+        production-deploy: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         publish-dir: './dist'
         github-token: ${{ secrets.GITHUB_TOKEN }}
         deploy-message: 'Deploy from GitHub Actions'


### PR DESCRIPTION
I added this filter last minute and didn't properly test it, sorry! This made the build-and-deploy workflow never update the production version of the website, even on `master` pushes.

Tested this change properly this time on my fork:
- Push to !master branch: deploy to prod skipped: https://github.com/delroth/nix.dev/actions/runs/6747929742/job/18345154135
- Push to master branch: deploy to prod triggered: https://github.com/delroth/nix.dev/actions/runs/6747965397/job/18345263014