### PR TITLE
Remove specific software name from header in docs

### DIFF
--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -30,9 +30,9 @@ In this tutorial we'll take a look how to create reproducible shell environments
 
 - A basic understanding of the [Nix language](reading-nix-language)
 
-## Entering a shell with Python installed
+## Entering a shell with Node JS installed
 
-Suppose we a development environment in which Python 3 was installed.
+Suppose we a development environment in which Node JS was installed.
 The simplest possible way to accomplish this is via the `nix-shell -p` command:
 ```
 $ nix-shell -p git neovim nodejs

--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -30,7 +30,7 @@ In this tutorial we'll take a look how to create reproducible shell environments
 
 - A basic understanding of the [Nix language](reading-nix-language)
 
-## Entering a shell with Node JS installed
+## Entering a temporary shell
 
 Suppose we a development environment in which Node JS was installed.
 The simplest possible way to accomplish this is via the `nix-shell -p` command:


### PR DESCRIPTION
The original reason for this pull request has mostly been resolved in https://github.com/NixOS/nix.dev/pull/793, except for the header of the section of interest. The section originally mentioned Python, then the example was updated to concern Node.js. After a little discussion, removing the specific software name from the header was suggested, so that's what I've done here.

<details><summary>Original Pull Request description.</summary>

Python is mentioned in the docs, but then the example uses Node JS. I am new to Nix, so I don't want to update the example to fully use Python, so I did the simpler change of fixing the heading and mention of Python to instead say Node JS.

If someone wants to fix the example code, or change the text to NodeJS or Node.JS, or whatever, by all means. My goal here is just to make the docs more clear. Thanks!

I don't know if there's some build process that will fix the Table of Contents on the right-hand side: 

Python mentioned in ToC |
--- |
![image](https://github.com/NixOS/nix.dev/assets/10889879/224c975c-8731-4b4e-bfac-6ff404f53dd3) |

</details>