### PR TITLE
add SOURCE_DATE_EPOCH to Makefile to fix copyright year

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
+SOURCE_DATE_EPOCH = $(shell git log -1 --format=%ct)
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
-SOURCE_DATE_EPOCH = $(shell git log -1 --format=%ct)
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -14,6 +13,8 @@ PAPEROPT_letter = -D latex_paper_size=letter
 ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
+# Explicitly set SOURCE_DATE_EPOCH for Sphinx copyright
+SOURCE_DATE_EPOCH = $(shell date +%s)
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) sou
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 # Explicitly set SOURCE_DATE_EPOCH for Sphinx copyright
-SOURCE_DATE_EPOCH = $(shell date +%s)
+SOURCE_DATE_EPOCH = $(shell date +%s --date='Jan 1')
 
 .PHONY: help
 help:


### PR DESCRIPTION
addresses: https://github.com/NixOS/nix.dev/issues/796
fix comes from this comment https://github.com/sphinx-doc/sphinx/issues/3451#issuecomment-373708110

git log time format is used in comment and I ran locally with that and the copyright prints correctly...but it'll break if not building from git so use `date +%s` instead to set `SOURCE_DATE_EPOCH`; `date +%Y` also should work but wasn't sure if it needed unix time or not so just went with that to be safe