### PR TITLE
Update documentation team meeting link

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -87,7 +87,7 @@ Contact [@fricklerhandwerk] to get a calendar invitation.
 
 ### Meeting links
 
-- [Jitsi conference](https://meet.jit.si/nix-documentation)
+- [Jitsi conference](https://jitsi.lassul.us/nix-documentation)
 - [Meeting notes scratchpad][collaborative scratchpad]
 - [GitHub project board]
 


### PR DESCRIPTION
The link in this repository is not used anymore. The new link was copied from the topic in the `#docs:nixos.org` room on Matrix.