### PR TITLE
build-and-deploy: Disable github deployments

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -40,4 +40,5 @@ jobs:
         overwrites-pull-request-comment: true
         enable-commit-comment: false
         enable-commit-status: true
+        enable-github-deployment: false
       if: github.repository_owner == 'NixOS'


### PR DESCRIPTION
They create a lot of spam in the PR timeline, e.g. see https://github.com/NixOS/nix.dev/pull/802#event-11027352082