### PR TITLE
review pass on tutorial sections

### DIFF
--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -69,7 +69,7 @@ which copies the whole directory to the Nix store on evaluation!
 :::
 
 :::{warning}
-With the [`flakes` experimental feature](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake) enabled, a local directory containing `flake.nix` is always copied into the Nix store *completely* unless it is a Git repository!
+With [experimental Flakes](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake), a local directory containing `flake.nix` is always copied into the Nix store *completely* unless it is a Git repository!
 :::
 
 This implicit coercion also works for files:
@@ -514,7 +514,7 @@ trace: - world.txt (regular)
 Notably, the approach of using `difference ./.` explicitly selects the files to _exclude_, which means that new files added to the source directory are included by default.
 Depending on your project, this might be a better fit than the alternative in the next section.
 
-## Union (include)
+## Union (explicitly include files)
 
 To contrast the previous approach, `unions` can also be used to select only the files to _include_.
 This means that new files added to the current directory would be ignored by default.
@@ -556,7 +556,7 @@ stdenv.mkDerivation {
     fileset = sourceFiles;
   };
   postInstall = ''
-    cp -vr $src $out
+    cp -vr . $out
   '';
 }
 ```
@@ -573,20 +573,13 @@ trace: - world.txt (regular)
 this derivation will be built:
   /nix/store/sjzkn07d6a4qfp60p6dc64pzvmmdafff-fileset.drv
 ...
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source' -> '/nix/store/zl4n1g6is4cmsqf02
-dci5b2h5zd0ia4r-fileset'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/build.sh' -> '/nix/store/zl4n1g6i
-s4cmsqf02dci5b2h5zd0ia4r-fileset/build.sh'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/hello.txt' -> '/nix/store/zl4n1g6
-is4cmsqf02dci5b2h5zd0ia4r-fileset/hello.txt'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/world.txt' -> '/nix/store/zl4n1g6
-is4cmsqf02dci5b2h5zd0ia4r-fileset/world.txt'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/src' -> '/nix/store/zl4n1g6is4cms
-qf02dci5b2h5zd0ia4r-fileset/src'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/src/select.c' -> '/nix/store/zl4n
-1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/src/select.c'
-'/nix/store/6k6pv78b1dkdhbdlzxar5vb3z3c8fwza-source/src/select.h' -> '/nix/store/zl4n
-1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/src/select.h'
+'.' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset'
+'./build.sh' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/build.sh'
+'./hello.txt' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/hello.txt'
+'./world.txt' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/world.txt'
+'./src' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/src'
+'./src/select.c' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/src/select.c'
+'./src/select.h' -> '/nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset/src/select.h'
 ...
 /nix/store/zl4n1g6is4cmsqf02dci5b2h5zd0ia4r-fileset
 ```
@@ -650,7 +643,7 @@ this derivation will be built:
 This includes too much though, as not all of these files are needed to build the derivation as originally intended.
 
 :::{note}
-With the [`flakes` experimental feature](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake) enabled, it's [not really possible](https://github.com/NixOS/nix/issues/9292) to use this function, even with
+With [experimental Flakes](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake), it's [not really possible](https://github.com/NixOS/nix/issues/9292) to use this function, even with
 
 ```shell-session
 nix build path:.

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -26,7 +26,7 @@ The file set library is based on the concept of _file sets_,
 a data type representing a collection of local files.
 File sets can be created, composed, and manipulated with the various functions of the library.
 
-The easiest way to experiment with the library is to use it through `nix repl`.
+The easiest way to experiment with the library is to use it through [`nix repl`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-repl):
 
 ```shell-session
 $ nix repl -f channel:nixos-unstable

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -413,7 +413,7 @@ trace: - world.txt (regular)
 /nix/store/vhyhk6ij39gjapqavz1j1x3zbiy3qc1a-fileset
 ```
 
-## Union (exclude)
+## Union (explicitly exclude files)
 
 There is still a problem:
 Changing _any_ of the included files causes the derivation to be rebuilt, even though it doesn't depend on those files.

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -1,5 +1,5 @@
 (file-sets)=
-# File sets
+# Working with local files
 <!-- TODO: Switch all mentions of unstable to stable once 23.11 is out -->
 
 To build a local project in a Nix derivation, its source files must be accessible to the builder.

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -20,7 +20,7 @@ Using these features directly can be tricky however:
 In this tutorial you'll learn how to use the [file set library](https://nixos.org/manual/nixpkgs/unstable/#sec-fileset) to work with local files in derivations.
 It abstracts over built-in functionality and offers a safer and more convenient interface.
 
-## Basics
+## File sets
 
 The file set library is based on the concept of _file sets_,
 a data type representing a collection of local files.

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -46,6 +46,17 @@ All functions that expect a file set for an argument also accept a [path](https:
 Such path arguments are then [implicitly coerced](https://nixos.org/manual/nixpkgs/unstable/#sec-fileset-path-coercion), and the resulting file sets contain _all_ files under the given path.
 In the previous trace this is indicated by `(all files in directory)`.
 
+:::{tip}
+The `trace` function pretty-prints its first agument and returns its second argument.
+But since you often just need the pretty-printing in `nix repl`, you can omit the second argument:
+
+```shell-session
+nix-repl> fs.trace ./.
+trace: /home/user (all files in directory)
+«lambda @ /nix/store/1czr278x24s3bl6qdnifpvm5z03wfi2p-nixpkgs-src/lib/fileset/default.nix:555:8»
+```
+:::
+
 Even though file sets conceptually contain local files,
 they _never_ add these files to the Nix store unless explicitly requested.
 So even though we pretty-printed all files in your home directory, none of its contained files were imported because of that.
@@ -61,17 +72,6 @@ which _does_ add all of its contained files to the Nix store!
 With current experimental Flakes,
 the local files always get copied into the Nix store
 unless you use it within a Git repository!
-:::
-
-:::{tip}
-The `trace` function pretty-prints its first agument and returns its second argument.
-But since you often just need the pretty-printing in `nix repl`, you can omit the second argument:
-
-```shell-session
-nix-repl> fs.trace ./.
-trace: /home/user (all files in directory)
-«lambda @ /nix/store/1czr278x24s3bl6qdnifpvm5z03wfi2p-nixpkgs-src/lib/fileset/default.nix:555:8»
-```
 :::
 
 This implicit coercion also works for files:

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -124,6 +124,12 @@ in
 pkgs.callPackage ./build.nix { }
 ```
 
+Add a source file to work with:
+
+```shell-session
+echo Hello, file set! > string.txt
+```
+
 From now on we'll just change the contents of `build.nix` while keeping `default.nix` the same.
 
 For now, let's have a simple `build.nix` to verify everything works so far:

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -80,11 +80,9 @@ trace: /etc/nix
 trace: - nix.conf (symlink)
 ```
 
-We can see that in addition to the included file,
-it also prints its [file type](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-readFileType).
+In addition to the included file, this also prints its [file type](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-readFileType).
 
-But if we make a typo for a path that doesn't exist,
-the library adequately complains about it:
+If a given path doesn't exist, the library will complain:
 
 ```shell-session
 nix-repl> fs.trace /etc/nix/nix.nix

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -106,16 +106,16 @@ $ nix-shell -p niv --run "niv init --nixpkgs nixos/nixpkgs --nixpkgs-branch nixo
 We're using the `nixos-unstable` channel branch here, since no stable release has all the features needed for this tutorial.
 :::
 
-Then create a `default.nix` file:
+Then create a `default.nix` file with the following contents:
 
 ```{code-block} nix
 :caption: default.nix
 {
   system ? builtins.currentSystem,
-  sources ? import ./nix/sources.nix,
+  inputs ? import ./nix/sources.nix,
 }:
 let
-  pkgs = import sources.nixpkgs {
+  pkgs = import inputs.nixpkgs {
     config = { };
     overlays = [ ];
     inherit system;

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -34,9 +34,7 @@ $ nix repl -f channel:nixos-unstable
 nix-repl> fs = lib.fileset
 ```
 
-It's probably the easiest to just jump right in
-by using the [`trace`](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.fileset.trace) function,
-which pretty-prints the files included in a given file set:
+The [`trace`](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.fileset.trace) function pretty-prints the files included in a given file set:
 
 ```shell-session
 nix-repl> fs.trace ./. null

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -57,15 +57,15 @@ trace: /home/user (all files in directory)
 ```
 :::
 
-Even though file sets conceptually contain local files,
-they _never_ add these files to the Nix store unless explicitly requested.
-So even though we pretty-printed all files in your home directory, none of its contained files were imported because of that.
+Even though file sets conceptually contain local files, these files are *never* added to the Nix store unless explicitly requested.
+You don't have to worry about accidentally copying secrets into the world-readable store.
+
+In this example, although we pretty-printed the home directory, no files were copied.
 This is also evident from the expression evaluating instantly.
-So you don't have to worry about accidentally copying secrets into the store.
 
 :::{note}
-This is in contrast to coercion of paths to strings like in `"${./.}"`,
-which _does_ add all of its contained files to the Nix store!
+This is in contrast to coercion of paths to strings such as in `"${./.}"`,
+which copies the whole directory to the Nix store on evaluation!
 :::
 
 :::{warning}

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -103,7 +103,7 @@ $ nix-shell -p niv --run "niv init --nixpkgs nixos/nixpkgs --nixpkgs-branch nixo
 ```
 
 :::{note}
-For now we're using the nixos-unstable channel, since no stable channel has all the features we need yet.
+We're using the `nixos-unstable` channel branch here, since no stable release has all the features needed for this tutorial.
 :::
 
 Then create a `default.nix` file:

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -90,10 +90,10 @@ error: lib.fileset.trace: Argument (/etc/nix/nix.nix)
   is a path that does not exist.
 ```
 
-## A local directory
+## Example project
 
-To further experiment with the library, let's set up a local directory.
-To start out, create a new directory, enter it,
+To further experiment with the library, make a sample project.
+Create a new directory, enter it,
 and set up `niv` to pin the Nixpkgs dependency:
 
 ```shell-session

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -539,7 +539,7 @@ trace: - string.txt (regular)
 
 ## Conclusion
 
-You've now seen some examples on how to use all of the fundamental file set combinator functions.
-But if you need more complex behavior, you can compose them however necessary.
+We have shown some examples on how to use all of the fundamental file set functions.
+For more complex behavior, they can be composed as needed.
 
-For the complete list and more details, see the [reference documentation](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset).
+For the complete list and more details, see the [`lib.fileset` reference documentation](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset).

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -511,7 +511,7 @@ trace: - world.txt (regular)
 /nix/store/ckn40y7hgqphhbhyrq64h9r6rvdh973r-fileset
 ```
 
-Notably, with this approach, new files added to the source directory are _included_ by default.
+Notably, the approach of using `difference ./.` explicitly selects the files to _exclude_, which means that new files added to the source directory are included by default.
 Depending on your project, this might be a better fit than the alternative in the next section.
 
 ## Union (include)

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -17,9 +17,8 @@ Using these features directly can be tricky however:
   can address these problems.
   However, it's often hard to express the desired path selection using the `filter` function interface.
 
-In this tutorial you'll learn how to use the [file set library](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset) instead.
-It abstracts over these functions with essentially the same functionality,
-but an easier and safer interface.
+In this tutorial you'll learn how to use the [file set library](https://nixos.org/manual/nixpkgs/unstable/#sec-fileset) to work with local files in derivations.
+It abstracts over built-in functionality and offers a safer and more convenient interface.
 
 ## Basics
 

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -42,12 +42,9 @@ trace: /home/user (all files in directory)
 null
 ```
 
-You might wonder where the file set here is, because we just passed a [_path_](https://nixos.org/manual/nix/stable/language/values#type-path) to the function!
-
-The key is that for all functions that expect a file set for an argument, they _also_ accepts paths.
-Such path arguments are then [implicitly coerced](https://nixos.org/manual/nixpkgs/unstable/#sec-fileset-path-coercion).
-The resulting file sets contain _all_ files under the given path.
-We can see this from the trace `/home/user (all files in directory)`
+All functions that expect a file set for an argument also accept a [path](https://nixos.org/manual/nix/stable/language/values#type-path).
+Such path arguments are then [implicitly coerced](https://nixos.org/manual/nixpkgs/unstable/#sec-fileset-path-coercion), and the resulting file sets contain _all_ files under the given path.
+In the previous trace this is indicated by `(all files in directory)`.
 
 Even though file sets conceptually contain local files,
 they _never_ add these files to the Nix store unless explicitly requested.

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -2,15 +2,9 @@
 # Working with local files
 <!-- TODO: Switch all mentions of unstable to stable once 23.11 is out -->
 
-To build a local project in a Nix derivation, its source files must be accessible to the builder.
-But since the builder runs in an isolated environment (if the [sandbox](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox) is enabled),
-it won't have access to the local project files by default.
-
-To make this work regardless, the Nix language has certain builtin features to copy local paths to the Nix store,
-whose paths are then accessible to derivation builders [^1].
-
-[^1]: Technically only Nix store paths from the derivations inputs can be accessed,
-but in practice this distinction is not important.
+To build a local project in a Nix derivation, its source files must be accessible to the [`builder` executable](https://nixos.org/manual/nix/stable/language/derivations#attr-builder).
+Since by default the `builder` runs in an isolated environment that only allows reading from the Nix store,
+the Nix language has built-in features to copy local files to the store and expose the resulting store paths.
 
 Using these features directly can be tricky however:
 

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -69,9 +69,7 @@ which copies the whole directory to the Nix store on evaluation!
 :::
 
 :::{warning}
-With current experimental Flakes,
-the local files always get copied into the Nix store
-unless you use it within a Git repository!
+With the [`flakes` experimental feature](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake) enabled, a local directory containing `flake.nix` is always copied into the Nix store *completely* unless it is a Git repository!
 :::
 
 This implicit coercion also works for files:

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -203,7 +203,7 @@ t.drv'.
 That's where [`toSource`](https://nixos.org/manual/nixpkgs/unstable/#function-library-lib.fileset.toSource) comes in:
 It adds exactly the files in the given file set to a directory in the Nix store, starting from a specified root path.
 
-Define `package.nix` as follows:
+Define `build.nix` as follows:
 
 ```{code-block} nix
 :caption: build.nix

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -24,7 +24,7 @@ It abstracts over built-in functionality and offers a safer and more convenient 
 
 The file set library is based on the concept of _file sets_,
 a data type representing a collection of local files.
-File sets can be created, composed and used with the various functions of the library.
+File sets can be created, composed, and manipulated with the various functions of the library.
 
 The easiest way to experiment with the library is to use it through `nix repl`.
 

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -15,7 +15,7 @@ Using these features directly can be tricky however:
 - The [`builtins.path`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-path) function
   (and equivalently [`lib.sources.cleanSourceWith`](https://nixos.org/manual/nixpkgs/stable/#function-library-lib.sources.cleanSourceWith))
   can address these problems.
-  However, it's hard to get the desired path selection using the `filter` function interface.
+  However, it's often hard to express the desired path selection using the `filter` function interface.
 
 In this tutorial you'll learn how to use the [file set library](https://nixos.org/manual/nixpkgs/unstable/#sec-functions-library-fileset) instead.
 It abstracts over these functions with essentially the same functionality,

--- a/source/tutorials/file-sets.md
+++ b/source/tutorials/file-sets.md
@@ -30,7 +30,7 @@ The easiest way to experiment with the library is to use it through [`nix repl`]
 
 ```shell-session
 $ nix repl -f channel:nixos-unstable
-[...]
+...
 nix-repl> fs = lib.fileset
 ```
 
@@ -231,7 +231,7 @@ $ nix-build
 trace: /home/user/select (all files in directory)
 this derivation will be built:
   /nix/store/d8mj3z49s24q46rncma6v9kvi6xbx4vq-filesets.drv
-[...]
+...
 /nix/store/v5sx60xd9lvylgqcyqpchac1a2k8300c-filesets
 ```
 
@@ -242,7 +242,7 @@ $ nix-build
 trace: /home/user/select (all files in directory)
 this derivation will be built:
   /nix/store/1xb412x3fzavr8d8c3hbl3fv9kyvj77c-filesets.drv
-[...]
+...
 /nix/store/n9i6gaf80hvbfplsv7zilkbfrz47s4kn-filesets
 ```
 
@@ -276,11 +276,11 @@ trace: - package.nix (regular)
 trace: - string.txt (regular)
 this derivation will be built:
   /nix/store/7960rh64d4zlkspmf4h51g4zys3lcjyj-filesets.drv
-[...]
+...
 /nix/store/aicvbzjvqzn06nbgpbrwqi47rxqdiqv9-filesets
 
 $ nix-build
-[...]
+...
 /nix/store/aicvbzjvqzn06nbgpbrwqi47rxqdiqv9-filesets
 ```
 
@@ -314,7 +314,7 @@ $ nix-build
 trace: /home/user/select (all files in directory)
 this derivation will be built:
   /nix/store/ygpx17kshzc6bj3c71xlda8szw6qi1sr-filesets.drv
-[...]
+...
 /nix/store/bzvhlr9h2zwqi7rr9i1j193z9hkskhmk-filesets
 
 $ nix-build
@@ -343,7 +343,7 @@ trace: - package.nix (regular)
 trace: - string.txt (regular)
 this derivation will be built:
   /nix/store/zmgpqlpfz2jq0w9rdacsnpx8ni4n77cn-filesets.drv
-[...]
+...
 /nix/store/6pffjljjy3c7kla60nljk3fad4q4kkzn-filesets
 ```
 
@@ -441,7 +441,7 @@ trace: - string.txt (regular)
 this derivation will be built:
   /nix/store/gzj9j9dk2qyd46y1g2wkpkrbc3f2nm5g-filesets.drv
 building '/nix/store/gzj9j9dk2qyd46y1g2wkpkrbc3f2nm5g-filesets.drv'...
-[...]
+...
 /nix/store/sb4g8skwvpwbay5kdpnyhwjglxqzim28-filesets
 
 $ touch src/select.o
@@ -500,7 +500,7 @@ trace:   - select.h (regular)
 trace: - string.txt (regular)
 this derivation will be built:
   /nix/store/vn21azx8y06cjq80lrvib8ia4xxpwn3d-filesets.drv
-[...]
+...
 /nix/store/4xdfxm910x1i2qapv49caiibymfjhvla-filesets
 ```
 


### PR DESCRIPTION
it's a huge diff, but it doesn't change that much:
- start with a `mkDerivation` scaffold that uses `src = ./.`
  - this saves the detour with an intentionally broken derivation and
    the explanation it requires
  - it provides an opportunity to drop another bit of information about
    `toSource`, namely that it always creates a directory in the store
- use two source files to start with, otherwise the "try one file, then
  the whole directory" approach is not well-motivated
  - this obviates spending words on justifying a contrived example,
    it flows more naturally
- mostly use diffs to highlight the changes
  - this is not a strong proposal
  - the explicit-include-union example starts over, so the build-up is
    manageable
  - it works out quite nicely overall: since there is sufficient repetition
    where we reasonably expect learners to have gotten the point,
    the last two sections can be reduced just to the relevant bit.
- rename section headers to match functions, not domain problems
  - one exception is the split of the two union approaches, which should
    be okay
- reword all instructions to be imperative


the review made clear how powerful and elegant the library is, and that the
tutorial is utterly well-structured and ordered in a way that feels natural
and covers all important aspects!

great job @infinisil!