### PR TITLE
move question on rechecking binary cache to a Nix recipe 

### DIFF
--- a/source/guides/faq.md
+++ b/source/guides/faq.md
@@ -29,21 +29,6 @@ $ echo "trusted-binary-caches = https://cache.nixos.org" >> /etc/nix/nix.conf
 $ nix-build helpers/bench.nix --option extra-binary-caches https://cache.nixos.org
 ```
 
-### How do I force nix to re-check whether something exists at a binary cache?
-
-Nix caches the contents of binary caches so that it doesn't have to query them
-on every command. This includes negative answers (cache doesn't have something).
-The default timeout for that is 1 hour as of writing.
-
-To wipe all cache-lookup-caches:
-
-```shell-session
-$ rm $HOME/.cache/nix/binary-cache-v*.sqlite*
-```
-
-Alternatively, use the `narinfo-cache-negative-ttl` option to reduce the
-cache timeout.
-
 ### How to operate between Nix paths and strings?
 
 See <http://stackoverflow.com/a/43850372>

--- a/source/guides/recipes/index.md
+++ b/source/guides/recipes/index.md
@@ -7,5 +7,6 @@
 sharing-dependencies.md
 Automatic environments <direnv>
 dependency-management.md
+nix-recipes.md
 Python development environment <./python-environment.md>
 ```

--- a/source/guides/recipes/nix-recipes.md
+++ b/source/guides/recipes/nix-recipes.md
@@ -1,0 +1,14 @@
+### How do I force nix to re-check whether something exists at a binary cache?
+
+Nix caches the contents of binary caches so that it doesn't have to query them
+on every command. This includes negative answers (cache doesn't have something).
+The default timeout for that is 1 hour as of writing.
+
+To wipe all cache-lookup-caches:
+
+```shell-session
+$ rm $HOME/.cache/nix/binary-cache-v*.sqlite*
+```
+
+Alternatively, use the `narinfo-cache-negative-ttl` option to reduce the
+cache timeout.

--- a/source/guides/recipes/nix-recipes.md
+++ b/source/guides/recipes/nix-recipes.md
@@ -1,6 +1,6 @@
 # Nix
 
-## How do I force nix to re-check whether something exists at a binary cache?
+## Forcing Nix to re-check if something exists in the binary cache?
 
 Nix caches the contents of binary caches so that it doesn't have to query them
 on every command. This includes negative answers (cache doesn't have something).

--- a/source/guides/recipes/nix-recipes.md
+++ b/source/guides/recipes/nix-recipes.md
@@ -1,4 +1,6 @@
-### How do I force nix to re-check whether something exists at a binary cache?
+# Nix
+
+## How do I force nix to re-check whether something exists at a binary cache?
 
 Nix caches the contents of binary caches so that it doesn't have to query them
 on every command. This includes negative answers (cache doesn't have something).

--- a/source/guides/recipes/nix-recipes.md
+++ b/source/guides/recipes/nix-recipes.md
@@ -1,10 +1,10 @@
 # Nix
 
-## Forcing Nix to re-check if something exists in the binary cache?
+## Forcing Nix to re-check if something exists in the binary cache
 
-Nix caches the contents of binary caches so that it doesn't have to query them
-on every command. This includes negative answers (cache doesn't have something).
-The default timeout for that is 1 hour as of writing.
+Nix stores the contents of binary caches so it doesn't have to query them on every command.
+This includes negative answers (if cache is empty).
+The default timeout for negative lookups is 1 hour at the time of writing.
 
 To wipe all cache-lookup-caches:
 
@@ -12,5 +12,4 @@ To wipe all cache-lookup-caches:
 $ rm $HOME/.cache/nix/binary-cache-v*.sqlite*
 ```
 
-Alternatively, use the `narinfo-cache-negative-ttl` option to reduce the
-cache timeout.
+In that regard, pass the [`narinfo-cache-negative-ttl`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-narinfo-cache-negative-ttl) option to the `nix.conf` file to reduce the cache timeout.


### PR DESCRIPTION
Continuing with the restructuring of the FAQs, this PR moves:

- [How do I force nix to re-check whether something exists at a binary cache?](https://nix.dev/recipes/faq#how-do-i-force-nix-to-re-check-whether-something-exists-at-a-binary-cache)

to a new `Nix` file under Recipes, file in which the next and 5 remaining FAQs can get added to, in order to avoid convoluting the sidebar with so many entries.

(
Remaining questions:
- [How do I add a new binary cache?](https://nix.dev/recipes/faq#how-do-i-add-a-new-binary-cache)
- [How to operate between Nix paths and strings?](https://nix.dev/recipes/faq#how-to-operate-between-nix-paths-and-strings)
- [How to build reverse dependencies of a package?](https://nix.dev/recipes/faq#how-to-build-reverse-dependencies-of-a-package)
- [How can I manage dotfiles in $HOME with Nix?](https://nix.dev/recipes/faq#how-can-i-manage-dotfiles-in-home-with-nix)
- [What’s the recommended process for building custom packages?](https://nix.dev/recipes/faq#what-s-the-recommended-process-for-building-custom-packages)
)

A slight rewording of a few sentences has been made for clarity. I went out on a limb though and did some terminology changes, hope they are accurate.