### PR TITLE
tutorials: fix passing paramaters to geocode

### DIFF
--- a/source/tutorials/module-system/module-system.md
+++ b/source/tutorials/module-system/module-system.md
@@ -495,7 +495,7 @@ Then define the value for that option where you make the raw script reproducible
 +    scripts.geocode = pkgs.writeShellApplication {
 +      name = "geocode";
 +      runtimeInputs = with pkgs; [ curl jq ];
-+      text = ''exec ${./geocode} "$@" '';
++      text = ''exec ${./geocode} "$@"'';
 +    };
 +
      scripts.output = pkgs.writeShellApplication {

--- a/source/tutorials/module-system/module-system.md
+++ b/source/tutorials/module-system/module-system.md
@@ -495,7 +495,7 @@ Then define the value for that option where you make the raw script reproducible
 +    scripts.geocode = pkgs.writeShellApplication {
 +      name = "geocode";
 +      runtimeInputs = with pkgs; [ curl jq ];
-+      text = "exec ${./geocode}";
++      text = ''exec ${./geocode} "$@" '';
 +    };
 +
      scripts.output = pkgs.writeShellApplication {


### PR DESCRIPTION
When running the package as-is the following error occurs

``geocode: line 7: $1: unbound``

This is caused because ``scripts.geocode`` does not pass the parameters down to the wrapped script ``geocode``.

```
maps-module on main 
❯ cat ./result/bin/map 
#!/nix/store/kga2r02rmyxl14sg96nxbdhifq3rb8lc-bash-5.1-p16/bin/bash
set -o errexit
set -o nounset
set -o pipefail

export PATH="/nix/store/w8lpmghccjhdml5lds2bp1w6plzjb2m4-curl-7.86.0-bin/bin:/nix/store/r4bhjqsifqkqs573a0wlrbczrykn7bcr-feh-3.9/bin:$PATH"

/nix/store/mybhaciiwyk2d6xz7mmhw99pi25qdp29-map size=640x640 scale=2 zoom=7 center="$(/nix/store/4givzyglbn99qjaqfgc9wqk6shgkfhz2-geocode/bin/geocode 'switzerland')" | feh -
```

Examining geocode, we can see the wrapper that was created with `writeShellApplication`

```
maps-module on main
❯ cat /nix/store/4givzyglbn99qjaqfgc9wqk6shgkfhz2-geocode/bin/geocode
#!/nix/store/kga2r02rmyxl14sg96nxbdhifq3rb8lc-bash-5.1-p16/bin/bash
set -o errexit
set -o nounset
set -o pipefail

export PATH="/nix/store/w8lpmghccjhdml5lds2bp1w6plzjb2m4-curl-7.86.0-bin/bin:/nix/store/5cnq0rszbf91vap4ii260rzidaidp83z-jq-1.6-bin/bin:$PATH"

exec /nix/store/sdxcm79ja4vi93cy25amw7zhv677i726-geocode
```
As can be seen, the `geocode` script is called without any parameters.

This patch addresses this by ensurig the paramaters are passed over.