### PR TITLE
tutorial: Fix the markers to build and concatenate

### DIFF
--- a/source/tutorials/module-system/module-system.md
+++ b/source/tutorials/module-system/module-system.md
@@ -605,7 +605,7 @@ To implement this behavior, add the following `config` block to `marker.nix`:
 +      paramForMarker =
 +        builtins.map (marker: "$(${config.scripts.geocode}/bin/geocode ${
 +          lib.escapeShellArg marker.location})") config.map.markers;
-+    in ["markers=\"${lib.concatStringsSep "|" paramForMarker}\""];
++    in [ "markers=\"${lib.concatStringsSep "|" paramForMarker}\"" ];
 +  };
 ```
 

--- a/source/tutorials/module-system/module-system.md
+++ b/source/tutorials/module-system/module-system.md
@@ -602,18 +602,11 @@ To implement this behavior, add the following `config` block to `marker.nix`:
 +    ];
 +
 +    requestParams = let
-+      paramForMarker = marker:
-+        let
-+          attributes =
-+            [
-+              "$(geocode ${
-+                lib.escapeShellArg marker.location
-+              })"
-+            ];
-+        in "markers=${
-+          lib.concatStringsSep "\\|" attributes
-+        }";
-+    in builtins.map paramForMarker config.map.markers;
++      paramForMarker =
++        builtins.map (marker: "$(${config.scripts.geocode}/bin/geocode ${
++          lib.escapeShellArg marker.location})") config.map.markers;
++    in ["markers=\"${lib.concatStringsSep "|" paramForMarker}\""];
++  };
 ```
 
 :::{warning}


### PR DESCRIPTION
The current code has a number of issues.

1. realising the code results in:


```
markers=$(geocode 'New York') size=640x640 scale=2 zoom=7 ...
        ^-------------------^ SC2046 (warning): Quote this to prevent
        word splitting.
```


2.
`$(geocode ${lib.escapeShellArg marker.location})"`


Assumes that geocode has been added to the PATH so replace with below (as per previous examples).

`${config.scripts.geocode}/bin/geocode`


3.

 ```
 in "markers=${ lib.concatStringsSep "\\|" attributes}";
in builtins.map paramForMarker config.map.markers; 
```

The ordering of this actually creates multiple ``[markers =]`` parameters and does not use the concatenation string to join the attributes together (in effect there is only 1 attribute per call) to map, and 1 new ``marker`` created.