### PR TITLE
use upstream page redirects for Nix manual

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,7 @@
+# format documentation:
+# - https://docs.netlify.com/routing/redirects/#syntax-for-the-redirects-file
+# - https://docs.netlify.com/routing/redirects/redirect-options/
+
 /tutorials/install-nix /install-nix 301
 /anti-patterns/language /recipes/best-practices 301
 /faq /recipes/faq 301

--- a/default.nix
+++ b/default.nix
@@ -27,25 +27,28 @@ let
     '';
     installPhase =
       let
-        # Various versions of the Nix manuals, grep for (nix-manual)=
-        # FIXME: This requires human interaction to update!
-        # See ./CONTRIBUTING.md for details.
+        # Various versions of the Nix manuals, grep for (nix-manual)= to find where they are displayed
+        # FIXME: This requires human interaction to update! See ./CONTRIBUTING.md for details.
         releases = [
           "2.19"
           "2.18"
           "2.13"
         ];
         inputName = version: pkgs.lib.strings.replaceStrings [ "." ] [ "-" ] version;
-        src = version: (import inputs."nix_${inputName version}").default.doc;
+        src = version: inputs."nix_${inputName version}";
+        manual = version: (import (src version)).default.doc;
         copy = version: ''
-          cp -R ${src version}/share/doc/nix/manual/* $out/manual/nix/${version}
+          cp -Rf ${manual version}/share/doc/nix/manual/* $out/manual/nix/${version}
+          # add upstream page redirects of the form `<from> <to> <status>`, excluding comment lines and empty
+          sed '/^#/d;/^$/d;s#^\(.*\) \(.*\) #/manual/nix/${version}\1 /manual/nix/${version}\2 #g' ${src version}/doc/manual/_redirects >> $out/_redirects
         '';
       in
       with pkgs.lib.strings;
       ''
-        mkdir -p $out/manual/nix/{${concatStringsSep "," releases}}
-        ${concatStringsSep "\n" (map copy releases)}
+        # NOTE: the comma in the shell expansion makes it also work for singleton lists
+        mkdir -p $out/manual/nix/{${concatStringsSep "," releases},}
         cp -R build/html/* $out/
+        ${concatStringsSep "\n" (map copy releases)}
       '';
   };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://nixos.org/",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "56eb17906822f14bb348017315cb1ca643da900a",
-        "sha256": "1k0x63l9crkrhdgdclcx8mp6r9mcp4brs67l6hsii1ag8gy2gmj4",
+        "rev": "25f2dfc6e41d8c30e7abc443a7b262e34e49253b",
+        "sha256": "0lbp6yq92wpzi7kihbbma8d1c6q33msw95y0kmirfiikd8yvpvs7",
         "type": "tarball",
-        "url": "https://github.com/nixos/nix/archive/56eb17906822f14bb348017315cb1ca643da900a.tar.gz",
+        "url": "https://github.com/nixos/nix/archive/25f2dfc6e41d8c30e7abc443a7b262e34e49253b.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix_2-18": {
@@ -17,10 +17,10 @@
         "homepage": "https://nixos.org/",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "f5f4de6a550327b4b1a06123c2e450f1b92c73b6",
-        "sha256": "1g23sxsh9aj7sard5d3ijqfjqbh4fvlvyr73sj3dcdzcqiys5naq",
+        "rev": "60eb80593f3a18aebc7672ad7007cb23c14db061",
+        "sha256": "0nyssab6skn9qd7mz4v0y3ycnhck7is6agm0i26l1anrgs90x37l",
         "type": "tarball",
-        "url": "https://github.com/nixos/nix/archive/f5f4de6a550327b4b1a06123c2e450f1b92c73b6.tar.gz",
+        "url": "https://github.com/nixos/nix/archive/60eb80593f3a18aebc7672ad7007cb23c14db061.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nix_2-19": {
@@ -29,10 +29,10 @@
         "homepage": "https://nixos.org/",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "33bacbe220b49ceaaeb817354592a0102fbae087",
-        "sha256": "17fjz3mxqcszxfzpj48f8rqzdqavnnpibpi0ssw7vxmyybrqsqly",
+        "rev": "dc09e6193bffcab37d3d43107eae9464395ab51d",
+        "sha256": "0n117h0jz3aih41mg0kns8v6rjhmrg7r6p8azl55p32zrj02zyvm",
         "type": "tarball",
-        "url": "https://github.com/nixos/nix/archive/33bacbe220b49ceaaeb817354592a0102fbae087.tar.gz",
+        "url": "https://github.com/nixos/nix/archive/dc09e6193bffcab37d3d43107eae9464395ab51d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
follow-up on #764

~~this currently won't build because the pinned versions don't have the
redirects yet, and bumping them would require an expensive local build
that may fail as it does for Hydra.~~