### PR TITLE
add FAQ entry on how to run non-nix executables

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -25,3 +25,4 @@
 /recipes/direnv /guides/recipes/direnv 301
 /tutorials/learning-journey/sharing-dependencies /guides/recipes/sharing-dependencies 301
 /tutorials/learning-journey/packaging-existing-software /tutorials/packaging-existing-software 301
+/permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301


### PR DESCRIPTION
Adds an FAQ entry, primarily intended as a link target for the error message introduced in nixos/nixpkgs#269551.

Given that usecase, I do want to ask how much commitment to link stability is there on nix.dev? Is there perhaps a method to create a stable link that redirects to the proper location, so that external links can remain stable even if the site structure is changed?