### PR TITLE
doc: give hint regarding getting meeting link from latest commit

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -88,6 +88,7 @@ Contact [@fricklerhandwerk] to get a calendar invitation.
 ### Meeting links
 
 - [Jitsi conference](https://jitsi.lassul.us/nix-documentation)
+  - (when joining, make sure to use [the link provided at the latest commit](https://github.com/NixOS/nix.dev/blob/master/maintainers/README.md))
 - [Meeting notes scratchpad][collaborative scratchpad]
 - [GitHub project board]
 


### PR DESCRIPTION
When joining the meeting today, I used an incorrect link, as my browser served a GitHub page pointing to an older version of `maintainers/README.md`. 

For those who might be dealing with this issue in the future, including myself, I added a note+link regarding using the link from tip of master. 