### PR TITLE
disable linkcheck for GitHub anchor links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,23 +99,3 @@ We would be glad to incorporate your insights.
 ## Contributor guides
 
 Please read [Contributing Documentation](https://nix.dev/contributing/documentation).
-
-## GitHub heading anchors fails linkcheck
-
-Due to a [Sphinx bug][linkcheck gh bug], linkcheck fails when it verifies the
-existence of GitHub heading anchors on rendered Markdown documents.
-
-Until the bug is resolved, add the `user-content-` prefix to GitHub links
-containing heading anchors.
-
-For example, instead of
-
-```
-https://github.com/nix-community/nixos-generators#cross-compiling
-```
-
-use
-
-```
-https://github.com/nix-community/nixos-generators#user-content-cross-compiling
-```

--- a/source/conf.py
+++ b/source/conf.py
@@ -419,7 +419,7 @@ linkcheck_ignore = [
     # returns 403 on CI
     r"https://www.lesswrong.com",
     # Linkcheck fails on anchors in GH READMEs, see https://github.com/sphinx-doc/sphinx/issues/9016
-    r"https://github.com/cachix/install-nix-action#how-do-i-run-nixos-tests",
+    r"https://github.com/.+/.+#.+$",
     # Linkcheck fails on anchors in GH browser/file viewer, see https://github.com/sphinx-doc/sphinx/issues/11484
     r"https://github\.com/.+/.+/blob/.*#.*$",
     r"https://github\.com/.+/.+/tree/.*#.*$",


### PR DESCRIPTION
apparently it got (a lot) worse and GitHub doesn't render README files
statically any more.