### PR TITLE
Elaborate on `let` bindings

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -388,24 +388,6 @@ in
 2
 ```
 
-Attempting to use the value outside of the binding produces an error:
-
-```{code-block} nix
-:class: expression
-a
-```
-
-```{code-block}
-:class: value
-error: undefined variable 'a'
-
-       at «string»:1:1:
-
-            1| a
-             | ^
-```
-
-
 :::{dropdown} Detailed explanation
 
 Assignments are placed between the keywords `let` and `in`.

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -371,7 +371,7 @@ error: undefined variable 'one'
 
 Also known as “`let` expression” or “`let` binding”
 
-`let` expressions allow assigning names to values for scoped use.
+`let` expressions allow assigning names to values for repeated and scoped use.
 
 Example:
 

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -371,7 +371,7 @@ error: undefined variable 'one'
 
 Also known as “`let` expression” or “`let` binding”
 
-`let` expressions allow assigning names to values for repeated use.
+`let` expressions allow assigning names to values for scoped use.
 
 Example:
 
@@ -380,13 +380,31 @@ Example:
 let
   a = 1;
 in
-a + a
+  a + a
 ```
 
 ```{code-block}
 :class: value
 2
 ```
+
+Attempting to use the value outside of the binding produces an error:
+
+```{code-block} nix
+:class: expression
+a
+```
+
+```{code-block}
+:class: value
+error: undefined variable 'a'
+
+       at «string»:1:1:
+
+            1| a
+             | ^
+```
+
 
 :::{dropdown} Detailed explanation
 


### PR DESCRIPTION
The original documentation says let bindings are for "repeated use", though one can run

```nix
a = 3;
a + a
```

just fine without the binding. I think it's more appropriate to explain that `let` limits how far a value's name can reach. This is mentioned later, though, so I'm kind of puzzled on how to improve the language here and make it obvious *why* a let binding is a useful construction right up front.