### PR TITLE
Fix unquoted URL in "Nix language basics"

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1658,7 +1658,7 @@ A fully reproducible example would therefore look like this:
 ```{code-block} nix
 :class: expression
 let
-  nixpkgs = fetchTarball https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz;
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/archive/06278c77b5d162e62df170fec307e83f1812d94b.tar.gz";
   pkgs = import nixpkgs {};
 in
 pkgs.lib.strings.toUpper "always pin your sources"


### PR DESCRIPTION
I'm a newbie, so I might be missing something, but the use of an unquoted URL here seems like it goes against the ["Best Practice" page](https://nix.dev/guides/best-practices#urls), which says to always quote URLs.