### PR TITLE
use `nixShellNoCC` in tutorials and guides

### DIFF
--- a/source/guides/recipes/dependency-management.md
+++ b/source/guides/recipes/dependency-management.md
@@ -38,7 +38,7 @@ Add niv to the development environment for your project to have it readily avail
    build = pkgs.hello;
  in {
    inherit build;
-+  shell = pkgs.mkShell {
++  shell = pkgs.mkShellNoCC {
 +    inputsFrom = [ build ];
 +    packages = with pkgs; [
 +      niv

--- a/source/guides/recipes/direnv.md
+++ b/source/guides/recipes/direnv.md
@@ -14,7 +14,7 @@ let
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   packages = with pkgs; [
     hello
   ];
@@ -45,7 +45,7 @@ Make the following addition:
    pkgs = import nixpkgs { config = {}; overlays = []; };
  in
 
- pkgs.mkShell {
+ pkgs.mkShellNoCC {
    packages = with pkgs; [
      hello
    ];

--- a/source/guides/recipes/python-environment.md
+++ b/source/guides/recipes/python-environment.md
@@ -33,7 +33,7 @@ Create a new file `shell.nix` to declare the development environment:
 ```{code-block} nix shell.nix
 { pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-22.11") {} }:
 
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   packages = with pkgs; [
     (python3.withPackages (ps: [ ps.flask ]))
     curl

--- a/source/guides/recipes/sharing-dependencies.md
+++ b/source/guides/recipes/sharing-dependencies.md
@@ -7,7 +7,7 @@ How to share the package's dependencies in `default.nix` with the development en
 
 ## Summary
 
-Use the [`inputsFrom` attribute to `pkgs.mkShell`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell-attributes):
+Use the [`inputsFrom` attribute to `pkgs.mkShellNoCC`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell-attributes):
 
 ```nix
 # default.nix
@@ -17,7 +17,7 @@ let
 in
 {
   inherit build;
-  shell = pkgs.mkShell {
+  shell = pkgs.mkShellNoCC {
     inputsFrom = [ build ];
   };
 }
@@ -67,7 +67,7 @@ Add an attribute to `default.nix` specifying an environment:
  in
  {
    build = pkgs.callPackage ./build.nix {};
-+  shell = pkgs.mkShell {
++  shell = pkgs.mkShellNoCC {
 +  };
  }
 ```
@@ -84,7 +84,7 @@ Then take the package's dependencies into the environment with [`inputsFrom`](ht
  {
 -  build = pkgs.callPackage ./build.nix {};
 +  inherit build;
-   shell = pkgs.mkShell {
+   shell = pkgs.mkShellNoCC {
 +    inputsFrom = [ build ];
    };
  }

--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -56,7 +56,7 @@ let
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   packages = with pkgs; [
     git
     neovim
@@ -68,18 +68,19 @@ pkgs.mkShell {
 ::::{dropdown} Detailed explanation
 We use a version of [Nixpkgs pinned to a release branch](<ref-pinning-nixpkgs>), and explicitly set configuration options and overlays to avoid them being inadvertently overridden by [global configuration](https://nixos.org/manual/nixpkgs/stable/#chap-packageconfig).
 
-`mkShell` is a function that produces a shell environment.
-It takes as argument an attribute set.
+`nix-shell` was originally conceived as a way to construct a shell environment containing the [tools needed to debug package builds](https://nixos.org/manual/nixpkgs/stable/#sec-tools-of-stdenv), such as Make or GCC.
+Only later it became widely used as a general way to make temporary environments for other purposes.
+`mkShellNoCC` is a function that produces a such an environment, but without a compiler toolchain.
+
+`mkShellNoCC` takes as argument an attribute set.
 Here we give it an attribute `packages` with a list containing one item from the `pkgs` attribute set.
 
 :::{Dropdown} Side note on `packages` and `buildInputs`
-You may encounter examples of `mkShell` that add packages to the `buildInputs` or `nativeBuildInputs` attributes instead.
+You may encounter examples of `mkShell` or `mkShellNoCC` that add packages to the `buildInputs` or `nativeBuildInputs` attributes instead.
 
-`nix-shell` was originally conceived as a way to construct a shell environment containing the tools needed to debug package builds.
-Only later it became widely used as a general way to make temporary environments for other purposes.
 
-`mkShell` is a [wrapper around `mkDerivation`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell), so it takes the same arguments as `mkDerivation`, such as `buildInputs` or `nativeBuildInputs`.
-The `packages` attribute argument to `mkShell` is simply an alias for `nativeBuildInputs`.
+`mkShellNoCC` is a [wrapper around `mkDerivation`](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell), so it takes the same arguments as `mkDerivation`, such as `buildInputs` or `nativeBuildInputs`.
+The `packages` attribute argument to `mkShellNoCC` is simply an alias for `nativeBuildInputs`.
 :::
 ::::
 
@@ -108,7 +109,7 @@ Set your `GIT_EDITOR` to use the `nvim` from the shell environment:
    pkgs = import nixpkgs { config = {}; overlays = []; };
  in
 
- pkgs.mkShell {
+ pkgs.mkShellNoCC {
    packages = with pkgs; [
      git
      neovim
@@ -119,7 +120,7 @@ Set your `GIT_EDITOR` to use the `nvim` from the shell environment:
  }
 ```
 
-Any attribute name passed to `mkShell` that is not reserved otherwise and has a value which can be coerced to a string will end up as an environment variable.
+Any attribute name passed to `mkShellNoCC` that is not reserved otherwise and has a value which can be coerced to a string will end up as an environment variable.
 
 :::{dropdown} Detailed explanation
 
@@ -138,7 +139,7 @@ If you really need to override these protected environment variables, use the `s
 ## Startup commands
 
 You may want to run some commands before entering the shell environment.
-These commands can be placed in the `shellHook` attribute provided to `mkShell`.
+These commands can be placed in the `shellHook` attribute provided to `mkShellNoCC`.
 
 Set `shellHook` to output the current repository status:
 
@@ -148,7 +149,7 @@ Set `shellHook` to output the current repository status:
    pkgs = import nixpkgs { config = {}; overlays = []; };
  in
 
- pkgs.mkShell {
+ pkgs.mkShellNoCC {
    packages = with pkgs; [
      git
      neovim

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1935,7 +1935,7 @@ The goal of the following exercises is not to understand what the code means or 
 let
   message = "hello world";
 in
-pkgs.mkShell {
+pkgs.mkShellNoCC {
   buildInputs = with pkgs; [ cowsay ];
   shellHook = ''
     cowsay ${message}
@@ -1951,9 +1951,9 @@ Explanation:
 - If the argument has the attribute `pkgs`, it will be used in the function body.
   Otherwise, by default, import the Nix expression in the file found on the lookup path `<nixpkgs>` (which is a function in this case), call the function with an empty attribute set, and use the resulting value.
 - The name `message` is bound to the string value `"hello world"`.
-- The attribute `mkShell` of the `pkgs` set is a function that is passed an attribute set as argument.
+- The attribute `mkShellNoCC` of the `pkgs` set is a function that is passed an attribute set as argument.
   Its return value is also the result of the outer function.
-- The attribute set passed to `mkShell` has the attributes `buildInputs` (set to a list with one element: the `cowsay` attribute from `pkgs`) and `shellHook` (set to an indented string).
+- The attribute set passed to `mkShellNoCC` has the attributes `buildInputs` (set to a list with one element: the `cowsay` attribute from `pkgs`) and `shellHook` (set to an indented string).
 - The indented string contains an interpolated expression, which will expand the value of `message` to yield `"hello world"`.
 
 


### PR DESCRIPTION
in our examples we never actually use the compiler toolchain stuff from
`mkShell`, so we may as well not burden users with large downloads.

It's not as slick, but arguably better practice. @infinisil I've seen you using it that way, what do you think?

Thinking further, maybe we could add (and backport) an alias to it in Nixpkgs that has a more precise name that will be easier to phase out of in a better world where Nix allows actual environments (or entire shells) and Nixpkgs provides them?