### PR TITLE
fix mutable shortlinks

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,7 @@ let
           sed '/^#/d;/^$/d;s#^\(.*\) \(.*\) #/manual/nix/${version}\1 /manual/nix/${version}\2 #g' ${src version}/doc/manual/_redirects >> $out/_redirects
         '';
         shortlink = release: version: ''
-          echo /nix/manual/${release} /nix/manual/${version} >> $out/_redirects
+          echo /nix/manual/${release} /nix/manual/${version} 302 >> $out/_redirects
         '';
         versions = with pkgs.lib; lists.unique (attrsets.attrValues releases);
       in


### PR DESCRIPTION
they were missing a response status code

use 302 since those are explicitly not permanent:
https://datatracker.ietf.org/doc/html/rfc9110#name-302-found