### PR TITLE
run preview deployments on forks as well

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,11 +1,13 @@
 name: "Build and Deploy"
 on:
-  push: {}
-  pull_request: {}
+  workflow_run:
+    workflows: [Test]
+    types: [completed]
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
fixes #553

it follows the pattern in https://github.com/NixOS/nix.dev/pull/479, where the workflows are decoupled by `workflow_run`.
according to [GitHub documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run) that should do the trick of running workflows that require secrets.

there's probably no way to test this other than merging and trying out.