### PR TITLE
use a text-only configuration for the VM tutorial

### DIFF
--- a/source/tutorials/first-steps/index.md
+++ b/source/tutorials/first-steps/index.md
@@ -11,6 +11,6 @@ You will also learn reading the Nix language, and later use it to build portable
 :maxdepth: 1
 ad-hoc-shell-environments.md
 reproducible-scripts.md
-declarative-shell.md
+Declarative shell environments <declarative-shell.md>
 towards-reproducibility-pinning-nixpkgs.md
 ```

--- a/source/tutorials/nixos/nixos-configuration-on-vm.md
+++ b/source/tutorials/nixos/nixos-configuration-on-vm.md
@@ -258,6 +258,8 @@ rm nixos.qcow2
 - [Nix manual: `nix-build`](https://nix.dev/manual/nix/2.18/command-ref/nix-build.html).
 - [Nix manual: common command-line options](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html).
 - [Nix manual: `NIX_PATH` environment variable](https://nix.dev/manual/nix/2.18/command-ref/env-common.html#env-NIX_PATH).
+- [QEMU User Documentation](https://www.qemu.org/docs/master/system/qemu-manpage.html) for more runtime options
+- [NixOS option search: `virtualisation.qemu`](https://search.nixos.org/options?query=virtualisation.qemu) for declarative virtual machine configuration
 
 ## Next steps
 


### PR DESCRIPTION
@nh2 @olafklingt follow-up on #768

with the right flags it can be started in the current terminal.
when the VM stops, it's ungarbled with `reset`.

found this when trying to test a VM configuration without all the graphical hassle:
https://nixos.wiki/wiki/Cheatsheet#Building_a_service_as_a_VM_.28for_testing.29