### PR TITLE
Replace mobile Wikipedia links with desktop ones

### DIFF
--- a/maintainers/documentation-project-2023.md
+++ b/maintainers/documentation-project-2023.md
@@ -50,7 +50,7 @@ As stretch goals, implement particular lessons identified as the most impactful 
 
    1. Develop a draft for a learning journey
    1. Validate the draft with Nix experts
-   1. Make the resulting outline immediately visible for beginners at well-known [touchpoints](https://en.m.wikipedia.org/wiki/Touchpoint).
+   1. Make the resulting outline immediately visible for beginners at well-known [touchpoints](https://en.wikipedia.org/wiki/Touchpoint).
 
 1. Categorise existing documentation materials into the [Diátaxis framework](https://diataxis.fr), and arrange them in a meaningful order emerging from the curriculum.
 

--- a/source/contributing/documentation/style-guide.md
+++ b/source/contributing/documentation/style-guide.md
@@ -125,7 +125,7 @@ Integer volutpat erat sem, non varius turpis facilisis eu. Nam eu [ullamcorper][
 ```
 
 [ref_links]: https://github.github.com/gfm/#reference-link
-[permanent links]: https://en.m.wikipedia.org/wiki/Permalink
+[permanent links]: https://en.wikipedia.org/wiki/Permalink
 [GitHub URLs to specific commits]: https://docs.github.com/en/repositories/working-with-files/using-files/getting-permanent-links-to-files
-[Wikipedia URLs to specific page versions]: https://en.m.wikipedia.org/wiki/Wikipedia:Linking_to_Wikipedia#Permanent_links_to_old_versions_of_pages
+[Wikipedia URLs to specific page versions]: https://en.wikipedia.org/wiki/Wikipedia:Linking_to_Wikipedia#Permanent_links_to_old_versions_of_pages
 [Internet Archive "Save Page Now" for persisting web pages]: https://web.archive.org/save

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -208,7 +208,7 @@ $ nix-instantiate --eval --strict file.nix
 White space is used to delimit [lexical tokens], where required.
 It is otherwise insignificant.
 
-[lexical tokens]: https://en.m.wikipedia.org/wiki/Lexical_analysis#Lexical_token_and_lexical_tokenization
+[lexical tokens]: https://en.wikipedia.org/wiki/Lexical_analysis#Lexical_token_and_lexical_tokenization
 
 Line breaks, indentation, and additional spaces are for readers' convenience.
 
@@ -1236,7 +1236,7 @@ Multiple arguments can be handled by nesting functions.
 
 Such a nested function can be used like a function that takes multiple arguments, but offers additional flexibility.
 
-[curried]: https://en.m.wikipedia.org/wiki/Currying
+[curried]: https://en.wikipedia.org/wiki/Currying
 
 Example:
 


### PR DESCRIPTION
Wikipedia automatically redirects mobile users to the mobile version when clicking a desktop link, but doesn't do the same the other way around. This also introduces consistency, as some Wikipedia links use the desktop version and some the mobile version.