### PR TITLE
Fix link to Nix manual in contributing doc

### DIFF
--- a/source/contributing/documentation/index.md
+++ b/source/contributing/documentation/index.md
@@ -163,7 +163,7 @@ You can still help with
 
 Where to migrate what:
 
-- Nix interaction: [Nix manual]
+- Nix interaction: [Nix manual](nix-manual)
 - Language-specific build instructions: [Nixpkgs manual]
 - Package, service, or hardware configuration: [NixOS manual]
 - Overviews, tutorials, guides, best practices: [nix.dev]


### PR DESCRIPTION
See current broken link here: https://nix.dev/contributing/documentation/#wiki

This broke with https://github.com/NixOS/nix.dev/commit/8264c846ef8e492caae60304f2d4b6bd8d934c3d