### PR TITLE
Fixing typo in `integration-testing-using-virtual-machines` and `packaging-existing-software`

### DIFF
--- a/source/tutorials/nixos/integration-testing-using-virtual-machines.md
+++ b/source/tutorials/nixos/integration-testing-using-virtual-machines.md
@@ -307,7 +307,7 @@ The test script performs the following steps:
 Run the test:
 
 ```shell-session
-$ nix-build server-client-test.nix
+$ nix-build client-server-test.nix
 ```
 
 ## Additional information regarding NixOS tests

--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -454,7 +454,7 @@ Only clone the latest revision if you don't want to wait a long time:
 
 ```console
 $ nix-shell -p git ripgrep
-[nix-shell:~]$ git glone https://github.com/NixOS/nixpkgs --depth 1
+[nix-shell:~]$ git clone https://github.com/NixOS/nixpkgs --depth 1
 ```
 
 To narrow down results, specify which subdirectory you want to search:


### PR DESCRIPTION
Hello !

This PR fix two typo I found in the documentation