### PR TITLE
change file sets tutorial URL to match document title

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -29,4 +29,6 @@
 /recipes/direnv /guides/recipes/direnv 301
 /tutorials/learning-journey/sharing-dependencies /guides/recipes/sharing-dependencies 301
 /tutorials/learning-journey/packaging-existing-software /tutorials/packaging-existing-software 301
+/tutorials/file-sets /tutorials/working-with-local-files 301
+
 /permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301

--- a/source/guides/recipes/python-environment.md
+++ b/source/guides/recipes/python-environment.md
@@ -106,6 +106,6 @@ Others can now use the same shell environment as long as they have [Nix installe
 ## Next steps
 
 - [](packaging-existing-software)
-- [](file-sets)
+- [](file-sets-tutorial)
 - [](automatic-direnv)
 - [](./dependency-management.md)

--- a/source/tutorials/index.md
+++ b/source/tutorials/index.md
@@ -10,7 +10,7 @@ These sections contains series of lessons to get started.
 first-steps/index.md
 nix-language.md
 Packaging existing software <packaging-existing-software.md>
-file-sets.md
+working-with-local-files.md
 nixos/index.md
 cross-compilation.md
 module-system/module-system.md

--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -1,4 +1,4 @@
-(file-sets)=
+(file-sets-tutorial)=
 # Working with local files
 
 To build a local project in a Nix derivation, source files must be accessible to its [`builder` executable](https://nixos.org/manual/nix/stable/language/derivations#attr-builder).


### PR DESCRIPTION
this solves a weird interaction with automatically generated section IDs
where the section heading is the same as the file name.

fixes #920

@stablejoy thanks for reporting