### PR TITLE
work around link checker being blocked

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -417,6 +417,7 @@ linkcheck_ignore = [
     r"https://matrix.to",
     # returns 403 on CI
     r"https://www.lesswrong.com",
+    r"https://www.raspberrypi.(com|org)",
     # Linkcheck fails on anchors in GH READMEs, see https://github.com/sphinx-doc/sphinx/issues/9016
     r"https://github.com/.+/.+#.+$",
     # Linkcheck fails on anchors in GH browser/file viewer, see https://github.com/sphinx-doc/sphinx/issues/11484


### PR DESCRIPTION
this is a really annoying failure, but we probably can't do much other
than waiting for IP addresses to switch around or something...

closes #924 by sticking the head in the sand