### PR TITLE
add missing word in documentation team goals

### DIFF
--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -5,7 +5,7 @@ The Nix documentation team was formed to [flatten the infamous learning curve](h
 ## Goals
 
 - Ease learning, increase onboarding success and user retention
-- Improve organisation of knowledge
+- Improve organisation of Nix knowledge
 - Lead, guide, and support related community efforts
 
 ## Motivation


### PR DESCRIPTION
somehow "Nix" went missing from "Nix knowledge" in some transfer. it was still there in the original announcement: https://discourse.nixos.org/t/documentation-team-flattening-the-learning-curve/20003