### PR TITLE
fix code block header in callpackage.md

### DIFF
--- a/source/tutorials/callpackage.md
+++ b/source/tutorials/callpackage.md
@@ -226,7 +226,7 @@ This can become quite tedious quickly, especially for larger package sets.
 
 Use `lib.callPackageWith` to create your own `callPackage` based on an attribute set.
 
-```
+```{code-block} nix
 :caption: default.nix
 let
   pkgs = import <nixpkgs> { };

--- a/source/tutorials/callpackage.md
+++ b/source/tutorials/callpackage.md
@@ -230,7 +230,7 @@ Use `lib.callPackageWith` to create your own `callPackage` based on an attribute
 :caption: default.nix
 let
   pkgs = import <nixpkgs> { };
-  callPackage = lib.callPackageWith (pkgs // packages);
+  callPackage = pkgs.lib.callPackageWith (pkgs // packages);
   packages = {
     a = callPackage ./a.nix { };
     b = callPackage ./b.nix { };


### PR DESCRIPTION
This PR fixes the missing filename header in a code block.