### PR TITLE
correct the number of flake users

### DIFF
--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -68,7 +68,7 @@ In particular:
 This led to a situation where the stable interface was only sparsely maintained for multiple years, and repeatedly suffered breakages due to ongoing development.
 Meanwhile, the new interface was adopted widely enough for evolving its design without negatively affecting users to become very challenging.
 
-As of the [2022](https://discourse.nixos.org/t/2022-nix-survey-results/18983) and [2023](https://discourse.nixos.org/t/nix-community-survey-2023-results/33124) surveys, more than half of the respondents, a third of which are relative beginners, rely on experimental features.
+As of the [2023](https://discourse.nixos.org/t/nix-community-survey-2023-results/33124) survey, 84% respondents, rely on experimental features.
 {term}`Nixpkgs` as a contrasting example, while featuring a `flake.nix` for compatibility, does not depend on Nix experimental features in its code base.
 
 ## Should I use flakes in my project?


### PR DESCRIPTION
The statistic in
https://discourse.nixos.org/t/nix-community-survey-2023-results/33124 does also include N/A responses in the percentage, so the 58% is a bit misleading as the conclusion would be that 42% are still not using flakes. I dropped the 1/3 statement for now, because I couldn't find any information about that, but I can re-add it if this percentage is actually correct. I also dropped the 2022 results as it didn't seem to have the explicit question in it.

