### PR TITLE
Improve Documentation: Exclude Prompt Characters from Copied Shell Commands

### DIFF
--- a/source/tutorials/first-steps/ad-hoc-shell-environments.md
+++ b/source/tutorials/first-steps/ad-hoc-shell-environments.md
@@ -37,7 +37,7 @@ these 3 derivations will be built:
 
 Within the Nix shell, you can use the programs provided by these packages:
 
-```
+```console
 [nix-shell:~]$ cowsay Hello, Nix! | lolcat
 ```
 

--- a/source/tutorials/first-steps/ad-hoc-shell-environments.md
+++ b/source/tutorials/first-steps/ad-hoc-shell-environments.md
@@ -37,7 +37,7 @@ these 3 derivations will be built:
 
 Within the Nix shell, you can use the programs provided by these packages:
 
-```console
+```shell-session
 [nix-shell:~]$ cowsay Hello, Nix! | lolcat
 ```
 


### PR DESCRIPTION
Prevent the inclusion of the dollar sign and preceding characters when copying shell commands from the documentation by wrapping them in a `console` code block.