### PR TITLE
refactor: rename test.nix to default.nix for consistency

### DIFF
--- a/source/tutorials/module-system/module-system.md
+++ b/source/tutorials/module-system/module-system.md
@@ -224,7 +224,7 @@ First, make available a `pkgs` argument in your module evaluation by adding a mo
  pkgs.lib.evalModules {
    modules = [
 +    ({ config, ... }: { config._module.args = { inherit pkgs; }; })
-     ./test.nix
+     ./default.nix
    ];
  }
 ```


### PR DESCRIPTION
Bit of a nit pick but will keep the example consistent