### PR TITLE
highlight background of collapsed texts

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -112,3 +112,15 @@ html[data-theme="dark"] .highlight .gd {
 .navbar-nav li.toctree-l1 > ul {
   padding: 0;
 }
+
+html[data-theme="dark"] details {
+  background-color: #202736;
+  border: 1px solid #202736;
+  color: inherit !important;
+} 
+
+html[data-theme="light"] details {
+  background-color: #6097c1;
+  border: 1px solid #6097c1;
+  color: inherit !important;
+}

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -117,7 +117,7 @@ html[data-theme="dark"] details {
   background-color: #202736;
   border: 1px solid #202736;
   color: inherit !important;
-} 
+}
 
 html[data-theme="light"] details {
   background-color: #6097c1;


### PR DESCRIPTION
I usually think that text collapsed behind a details element is difficult to recognize as such. 
This is a proposal to highlight those elements with a blue background color.