### PR TITLE
replace unoffical wiki links with offical ones

### DIFF
--- a/maintainers/documentation-survey.md
+++ b/maintainers/documentation-survey.md
@@ -123,7 +123,7 @@ To better navigate the material and judge its relevance, every entry should prov
 ### Nix
 
 - https://nix.dev/tutorials/ad-hoc-developer-environments#what-is-a-shell-environment
-- https://nixos.wiki/wiki/Nix_Cookbook#Managing_storage
+- https://wiki.nixos.org/wiki/Nix_Cookbook#Managing_storage
 
 ### Nix language
 
@@ -131,7 +131,7 @@ To better navigate the material and judge its relevance, every entry should prov
 
 ### Nixpkgs
 
-- https://nixos.wiki/wiki/FAQ
+- https://wiki.nixos.org/wiki/FAQ
 - https://www.youtube.com/watch?v=D_IZ2EfW_8U
 - https://www.youtube.com/watch?v=5K_2RSjbdXc
 - https://www.youtube.com/watch?v=dGAL3gMXvug

--- a/source/tutorials/nixos/integration-testing-using-virtual-machines.md
+++ b/source/tutorials/nixos/integration-testing-using-virtual-machines.md
@@ -320,7 +320,7 @@ $ nix-build client-server-test.nix
 
   A good inspiration is [Matrix bridging with an IRC](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests/matrix/appservice-irc.nix).
 
-<!-- TODO: move examples from https://nixos.wiki/wiki/NixOS_Testing_library to the NixOS manual and troubleshooting tips to nix.dev -->
+<!-- TODO: move examples from https://wiki.nixos.org/wiki/NixOS_Testing_library to the NixOS manual and troubleshooting tips to nix.dev -->
 
 ## Next steps
 


### PR DESCRIPTION
We now have an unofficial wiki page, so we should link that one instead of the unofficial ones