### PR TITLE
best-practices: add a new tip for `rec`

### DIFF
--- a/source/guides/best-practices.md
+++ b/source/guides/best-practices.md
@@ -54,6 +54,20 @@ in {
 ```
 :::
 
+:::{tip}
+Self-reference can be achieved by explicitly naming the attribute set:
+
+```{code-block} nix
+:class: expression
+let
+  argset = {
+    a = 1;
+    b = argset.a + 2;
+  };
+in
+  argset
+```
+:::
 
 ## `with` scopes
 


### PR DESCRIPTION
I believe it is more `rec`-like for those who need/like `rec`.