### PR TITLE
fix syntax error

### DIFF
--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -52,7 +52,7 @@ To start, consider this skeleton derivation:
 ```nix
 { stdenv }:
 
-stdenv.mkDerivation {	};
+stdenv.mkDerivation {	}
 ```
 
 This is a function which takes an attribute set containing `stdenv`, and produces a derivation (which currently does nothing).


### PR DESCRIPTION
Update packaging-existing-software.md - fix syntax error in skeleton derivation example. 
Remove `;` from
```
{ stdenv }:
stdenv.mkDerivation {	};
```
This gives `error: syntax error, unexpected ';', expecting end of file`

Removing the semicolon:
```
nix-instantiate --eval --expr '{ stdenv }: stdenv.mkDerivation {}'
<LAMBDA>
```