### PR TITLE
Minor team doc improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,7 @@
 # This also holds true for GitHub teams. Since almost none of our teams have write
 # permissions, you need to list all members of the team with commit access individually.
 
-* @NixOS/documentation-reviewers
+* @NixOS/documentation-team
 
 /.github/workflows/ @asymmetric
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -22,7 +22,7 @@ The team’s reason to exist is to make that principle discoverable and reproduc
 
 ## Members
 
-Current members are listed on the GitHub team [`@NixOS/documentation-team`](https://github.com/orgs/NixOS/teams/documentation-team).
+Current members are listed on [the website](https://nixos.org/community/teams/documentation/), and can be pinged using the GitHub team [`@NixOS/documentation-team`](https://github.com/orgs/NixOS/teams/documentation-team).
 
 ## Responsibilities
 

--- a/maintainers/README.md
+++ b/maintainers/README.md
@@ -24,8 +24,6 @@ The team’s reason to exist is to make that principle discoverable and reproduc
 
 Current members are listed on the GitHub team [`@NixOS/documentation-team`](https://github.com/orgs/NixOS/teams/documentation-team).
 
-Ping [`@NixOS/documentation-reviewers`](https://github.com/orgs/NixOS/teams/documentation-reviewers) for documentation reviews.
-
 ## Responsibilities
 
 ### Team


### PR DESCRIPTION
- Remove mention of NixOS/documentation-reviewers team (I don't think we need this anymore now that @fricklerhandwerk is back)
- Link to https://nixos.org/community/teams/documentation.html (allows people without a GitHub account and not in the organisation to see the members)