### PR TITLE
Fix Nix manual links from search results

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -35,3 +35,6 @@
 /permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301
 /manual/nix/unstable https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download 200
 /manual/nix/development https://hydra.nixos.org/job/nix/master/build.x86_64-linux/latest/download 200
+
+# Fix Nix manual links from search results
+/manual/nix/*/stable/* /manual/nix/:splat 301


### PR DESCRIPTION
At the moment, links to the Nix manual in search results are broken. For example, if I search "nix.conf bash-prompt-prefix" in Google I get this link, which 404s:

https://nixos.org/manual/nix/stable/command-ref/conf-file

Removing `/stable`, however, yields a working link:

https://nixos.org/manual/nix/command-ref/conf-file

I'm not 100% sure that this is the right redirect approach in Netlify but I at least wanted to venture a possible solution.