### PR TITLE
fix up wording on post-build-hook guide

### DIFF
--- a/source/guides/recipes/add-binary-cache.md
+++ b/source/guides/recipes/add-binary-cache.md
@@ -1,3 +1,4 @@
+(custom-binary-cache)=
 # Configure Nix to use a custom binary cache
 
 Nix can be configured to use a binary cache with the [`substituters`](https://nix.dev/manual/nix/2.21/command-ref/conf-file.html#conf-substituters) and [`trusted-public-keys`](https://nix.dev/manual/nix/2.21/command-ref/conf-file.html#conf-trusted-public-keys) settings, either exclusively or in addition to cache.nixos.org.


### PR DESCRIPTION
- the title was misleading, because the guide is more about hooks than S3
binary caches.
- pointed Nix manual links to a fixed version
- one sentence per line
- linked the guide on configuring a binary cache

@proofconstruction