### PR TITLE
JSON convert in modules error

### DIFF
--- a/source/tutorials/module-system/a-basic-module/default.nix
+++ b/source/tutorials/module-system/a-basic-module/default.nix
@@ -7,4 +7,4 @@ let
     ];
   };
 in
-  result.config
+result.config

--- a/source/tutorials/module-system/a-basic-module/default.nix
+++ b/source/tutorials/module-system/a-basic-module/default.nix
@@ -1,5 +1,5 @@
-{ pkgs ? import <nixpkgs> { } }:
 let
+  pkgs = import <nixpkgs> {};
   result = pkgs.lib.evalModules {
     modules = [
       ./options.nix
@@ -7,4 +7,4 @@ let
     ];
   };
 in
-result.config
+  result.config

--- a/source/tutorials/module-system/a-basic-module/eval.bash
+++ b/source/tutorials/module-system/a-basic-module/eval.bash
@@ -1,1 +1,1 @@
-nix-shell -p jq --run "nix-instantiate --eval --json | jq"
+nix-shell -p jq --run "nix-instantiate --eval --json --strict | jq"


### PR DESCRIPTION
Hi again, 
while continuing following and learning , under Section modules 

when you run script "./eval.bash" it shows
```
{ pkgs ? import <nixpkgs> { } }:
  ^
 error: cannot convert a function to JSON
```

can we convert function to json in nix? ( did i miss something )
so i just declared pkgs inside   "let .... in" block 

```
let
  pkgs = import <nixpkgs> {};
....
in
```

after executing it shows 
```
while evaluating attribute 'name'
error: cannot convert a function application to JSON
```

after reading wiki , i followed with    **--strict**
```
nix-shell -p jq --run "nix-instantiate --eval --json --strict | jq"
```

now it does show the expected output.
```
{
  "name": "Boaty McBoatface"
}
```

Please check on your end , i did double check about the error and also there might be better solution than this 
