### PR TITLE
dependency-management.md: update niv references

### DIFF
--- a/maintainers/documentation-survey.md
+++ b/maintainers/documentation-survey.md
@@ -254,13 +254,13 @@ To better navigate the material and judge its relevance, every entry should prov
 
 ### Nix
 
-- https://nix.dev/manual/nix/2.18/command-ref/command-ref.html
+- https://nix.dev/manual/nix/stable/command-ref/command-ref.html
 - https://edolstra.github.io/pubs/phd-thesis.pdf
 
 ### Nix language
 
 - https://edolstra.github.io/pubs/phd-thesis.pdf
-- https://nix.dev/manual/nix/2.18/expressions/writing-nix-expressions.html
+- https://nix.dev/manual/nix/stable/expressions/writing-nix-expressions.html
 - https://github.com/tazjin/nix-1p
 
 ### Nixpkgs

--- a/source/concepts/faq.md
+++ b/source/concepts/faq.md
@@ -61,7 +61,7 @@ Yes. There is:
 
 - CPU architecture—great effort being made to avoid compilation of native instructions in favour of hardcoded supported ones.
 - System's current time/date.
-- The filesystem used for building (see also [`TMPDIR`](https://nix.dev/manual/nix/2.18/command-ref/env-common.html#env-TMPDIR)).
+- The filesystem used for building (see also [`TMPDIR`](https://nix.dev/manual/nix/stable/command-ref/env-common.html#env-TMPDIR)).
 - Linux kernel parameters, such as:
   - [IPv6 capabilities](https://github.com/NixOS/nix/issues/5615).
   - binfmt interpreters, e.g., those configured with [`boot.binfmt.emulatedSystems`](https://search.nixos.org/options?show=boot.binfmt.emulatedSystems).

--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -5,11 +5,11 @@ What is usually referred to as "flakes" is:
 - A policy for managing dependencies between {term}`Nix expressions<Nix expression>`.
 - An [experimental feature] in Nix, implementing that policy and supporting functionality.
 
-[experimental feature]: https://nix.dev/manual/nix/2.18/contributing/experimental-features.html
+[experimental feature]: https://nix.dev/manual/nix/stable/contributing/experimental-features.html
 
 ## What are flakes?
 
-Technically, a [flake](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-flake.html#description) is a file system tree that contains a file named `flake.nix` in its root directory.
+Technically, a [flake](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake.html#description) is a file system tree that contains a file named `flake.nix` in its root directory.
 
 Flakes add the following behavior to Nix:
 
@@ -17,17 +17,17 @@ Flakes add the following behavior to Nix:
    - Other flakes are referenced as dependencies providing {term}`Nix language` code or other files.
    - The values produced by the {term}`Nix expression`s in `flake.nix` are structured according to pre-defined use cases.
 
-   [schema]: https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-flake.html#flake-format
+   [schema]: https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-format
 
-1. References to other flakes can be specified using a dedicated [URL-like syntax](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-flake.html#flake-references).
+1. References to other flakes can be specified using a dedicated [URL-like syntax](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake.html#flake-references).
    A [flake registry] allows using symbolic identifiers for further brevity.
    References can be automatically locked to their current specific version and later updated programmatically.
 
-   [flake registry]: https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-registry.html
+   [flake registry]: https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-registry.html
 
 1. A [new command line interface], implemented as a separate experimental feature, leverages flakes by accepting flake references in order to build, run, or deploy software defined as a flake.
 
-   [new command line interface]: https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix.html
+   [new command line interface]: https://nix.dev/manual/nix/stable/command-ref/new-cli/nix.html
 
 Nix handles flakes differently than regular {term}`Nix files <Nix file>` in the following ways:
 
@@ -55,12 +55,12 @@ In particular:
 - The RFC was closed without conclusion, and some fundamental issues are not yet resolved.
   For example:
   - The notion of a [global flake registry](https://github.com/NixOS/flake-registry) saw [substantial criticism](https://github.com/NixOS/rfcs/pull/49#issuecomment-635635333) that was never addressed.
-    While the source references of [registry entries can be pinned](https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-registry-pin), local registry names in Nix expressions [introduce mutable system state](https://github.com/NixOS/nix/issues/7422) and are thus, in that regard, no improvement over channels as managed by [`nix-channel`](https://nix.dev/manual/nix/2.18/command-ref/nix-channel).
+    While the source references of [registry entries can be pinned](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-registry-pin), local registry names in Nix expressions [introduce mutable system state](https://github.com/NixOS/nix/issues/7422) and are thus, in that regard, no improvement over channels as managed by [`nix-channel`](https://nix.dev/manual/nix/stable/command-ref/nix-channel).
   - It is [impossible to parameterise flakes](https://github.com/NixOS/nix/issues/2861).
     This means that [flakes downgrade ease of use of the `system` parameter](https://github.com/NixOS/nix/issues/3843) of derivations, for producers and consumers.
   - the flakes proposal was criticised for [trying to solve too many problems at once](https://github.com/nixos/rfcs/pull/49#issuecomment-521998933) and [at the wrong abstraction layer](https://discourse.nixos.org/t/nixpkgs-cli-working-group-member-search/30517).
     Part of this is that [the new command line interface and flakes are closely tied to each other](https://discourse.nixos.org/t/2023-03-06-nix-team-meeting-minutes-38/26056#cli-stabilisation-announcement-draft-4).
-- As [predicted by RFC reviewers](https://github.com/NixOS/rfcs/pull/49#issuecomment-588990425), the original implementation introduced [regressions](https://discourse.nixos.org/t/nix-2-4-and-what-s-next/16257) in the [Nix 2.4 release](https://nix.dev/manual/nix/2.18/release-notes/rl-2.4.html), breaking some stable functionality without a [major version](https://semver.org/) increment.
+- As [predicted by RFC reviewers](https://github.com/NixOS/rfcs/pull/49#issuecomment-588990425), the original implementation introduced [regressions](https://discourse.nixos.org/t/nix-2-4-and-what-s-next/16257) in the [Nix 2.4 release](https://nix.dev/manual/nix/stable/release-notes/rl-2.4.html), breaking some stable functionality without a [major version](https://semver.org/) increment.
 - Copying sources to the Nix store prior to evaluation adds a [significant performance penalty](https://github.com/NixOS/nix/issues/3121), especially for large repositories such as {term}`Nixpkgs`.
   Work to address this has been [in progress since May 2022](https://github.com/NixOS/nix/pull/6530), but risks introducing [its own set of issues](https://github.com/NixOS/nix/pull/6530#issuecomment-1850565931).
 - New Nix users were and still are encouraged by various individuals to adopt flakes despite there being no stability guarantees and no timeline to conclude the experiment.

--- a/source/contributing/how-to-contribute.md
+++ b/source/contributing/how-to-contribute.md
@@ -40,7 +40,7 @@ And it will lead to better code and documentation in the long run.
 
 We can only fix issues that we know of, so please report any issue you encounter.
 
-- Report issues with {term}`Nix` (including the [Nix reference manual](https://nixos.org/manual/nix/stable)) at <https://github.com/NixOS/nix/issues>.
+- Report issues with {term}`Nix` (including the [Nix reference manual](https://nix.dev/manual/nix/stable)) at <https://github.com/NixOS/nix/issues>.
 
 - Report issues with {term}`Nixpkgs` or {term}`NixOS` (including packages, configuration modules, the [Nixpkgs manual](https://nixos.org/manual/nixpkgs/stable), and the [NixOS manual](https://nixos.org/manual/nixos/stable)) at <https://github.com/NixOS/nixpkgs/issues>.
 

--- a/source/guides/best-practices.md
+++ b/source/guides/best-practices.md
@@ -133,7 +133,7 @@ You will often encounter Nix language code samples that refer to `<nixpkgs>`.
 `<...>` is special syntax that was [introduced in 2011] to conveniently access values from the environment variable [`$NIX_PATH`].
 
 [introduced in 2011]: https://github.com/NixOS/nix/commit/1ecc97b6bdb27e56d832ca48cdafd3dbb5185a04
-[`$NIX_PATH`]: https://nix.dev/manual/nix/2.18/command-ref/env-common.html#env-NIX_PATH
+[`$NIX_PATH`]: https://nix.dev/manual/nix/stable/command-ref/env-common.html#env-NIX_PATH
 
 This means, the value of a lookup path depends on external system state.
 When using lookup paths, the same Nix expression can produce different results.
@@ -141,7 +141,7 @@ When using lookup paths, the same Nix expression can produce different results.
 In most cases, `$NIX_PATH` is set to the latest channel when Nix is installed, and is therefore likely to differ from machine to machine.
 
 :::{note}
-[Channels](https://nix.dev/manual/nix/2.18/command-ref/nix-channel.html) are a mechanism for referencing remote Nix expressions and retrieving their latest version.
+[Channels](https://nix.dev/manual/nix/stable/command-ref/nix-channel.html) are a mechanism for referencing remote Nix expressions and retrieving their latest version.
 :::
 
 The state of a subscribed channel is external to the Nix expressions relying on it.
@@ -198,7 +198,7 @@ We skip it in minimal examples to reduce distractions.
 
 ## Updating nested attribute sets
 
-The [attribute set update operator](https://nix.dev/manual/nix/2.18/language/operators.html#update) merges two attribute sets.
+The [attribute set update operator](https://nix.dev/manual/nix/stable/language/operators.html#update) merges two attribute sets.
 
 Example:
 
@@ -264,7 +264,7 @@ If someone builds the project in a directory with a different name, they will ge
 This can be the cause of needless rebuilds.
 
 :::{tip}
-Use [`builtins.path`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-path) with the `name` attribute set to something fixed.
+Use [`builtins.path`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-path) with the `name` attribute set to something fixed.
 
 This will derive the symbolic name of the store path from `name` instead of the working directory:
 

--- a/source/guides/recipes/dependency-management.md
+++ b/source/guides/recipes/dependency-management.md
@@ -27,7 +27,7 @@ Import the generated `npins/default.nix` as the default value for the argument t
 }
 ```
 
-`nix-build` will call the top-level function with the empty attribute set `{}`, or with the attributes passed via [`--arg`](https://nixos.org/manual/nix/stable/command-ref/nix-build#opt-arg) or [`--argstr`](https://nixos.org/manual/nix/stable/command-ref/nix-build#opt-argstr).
+`nix-build` will call the top-level function with the empty attribute set `{}`, or with the attributes passed via [`--arg`](https://nix.dev/manual/nix/stable/command-ref/nix-build#opt-arg) or [`--argstr`](https://nix.dev/manual/nix/stable/command-ref/nix-build#opt-argstr).
 This pattern allows [overriding remote sources](overriding-sources-npins) programmatically.
 
 Add `npins` to the development environment for your project to have it readily available:

--- a/source/guides/recipes/dependency-management.md
+++ b/source/guides/recipes/dependency-management.md
@@ -63,7 +63,7 @@ See [](./sharing-dependencies) for details, and note that here you have to pass 
 
 As an example, we will use the previously created expression with an older version of Nixpkgs.
 
-Enter the development environment, create a new directory, and set up niv with a different version of Nixpkgs:
+Enter the development environment, create a new directory, and set up npins with a different version of Nixpkgs:
 
 ```shell-session
 $ nix-shell

--- a/source/guides/recipes/dependency-management.md
+++ b/source/guides/recipes/dependency-management.md
@@ -95,8 +95,9 @@ nix-build .. -A build --arg sources 'import ./npins'
 
 ## Migrating from `niv`
 
-A previous version of this guide recommended using [`niv`](https://github.com/nmattia/niv/), which is not maintained anymore.
-If you have a project using `niv`, import remote source definitions into `npins`:
+A previous version of this guide recommended using [`niv`](https://github.com/nmattia/niv/), a similar pin manager written in Haskell.
+
+If you have a project using `niv`, you can import remote source definitions into `npins`:
 
 ```shell-session
 npins import-niv

--- a/source/guides/troubleshooting.md
+++ b/source/guides/troubleshooting.md
@@ -4,14 +4,14 @@ This page is a collection of tips to solve problems you may encounter using Nix.
 
 ## What to do if a binary cache is down or unreachable?
 
-Pass [`--option substitute false`](https://nix.dev/manual/nix/2.18/command-ref/conf-file#conf-substitute) to Nix commands.
+Pass [`--option substitute false`](https://nix.dev/manual/nix/stable/command-ref/conf-file#conf-substitute) to Nix commands.
 
 ## How to force Nix to re-check if something exists in the binary cache?
 
 Nix keeps track of what's available in binary caches so it doesn't have to query them on every command.
 This includes negative answers, that is, if a given store path cannot be substituted.
 
-Pass the [`--narinfo-cache-negative-ttl`](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-narinfo-cache-negative-ttl) option to set the cache timeout in seconds.
+Pass the [`--narinfo-cache-negative-ttl`](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-narinfo-cache-negative-ttl) option to set the cache timeout in seconds.
 
 ## How to fix: `error: querying path in database: database disk image is malformed`
 
@@ -22,7 +22,7 @@ Try:
 $ sqlite3 /nix/var/nix/db/db.sqlite "pragma integrity_check"
 ```
 
-Which will print the errors in the [database](https://nix.dev/manual/nix/2.18/glossary#gloss-nix-database).
+Which will print the errors in the [database](https://nix.dev/manual/nix/stable/glossary#gloss-nix-database).
 If the errors are due to missing references, the following may work:
 
 ```shell-session
@@ -34,7 +34,7 @@ $ sqlite3 /nix/var/nix/db/db.sqlite-bkp ".dump" | sqlite3 /nix/var/nix/db/db.sql
 
 This is a [known issue](https://github.com/NixOS/nix/issues/1251).
 
-It means that using a new version of Nix upgraded the SQLite schema of the [database](https://nix.dev/manual/nix/2.18/glossary#gloss-nix-database), and then you tried to use an older version Nix.
+It means that using a new version of Nix upgraded the SQLite schema of the [database](https://nix.dev/manual/nix/stable/glossary#gloss-nix-database), and then you tried to use an older version Nix.
 
 The solution is to dump the database, and use the old Nix version to re-import the data:
 
@@ -47,6 +47,6 @@ $ nix-store --load-db < /tmp/db.dump
 
 ## How to fix: `writing to file: Connection reset by peer`
 
-This may mean you are trying to import a too large file or directory into the [Nix store](https://nix.dev/manual/nix/2.18/glossary#gloss-store), or your machine is running out of resources, such as disk space or memory.
+This may mean you are trying to import a too large file or directory into the [Nix store](https://nix.dev/manual/nix/stable/glossary#gloss-store), or your machine is running out of resources, such as disk space or memory.
 
-Try to reduce the size of the directory to import, or run [garbage collection](https://nix.dev/manual/nix/2.18/command-ref/nix-collect-garbage).
+Try to reduce the size of the directory to import, or run [garbage collection](https://nix.dev/manual/nix/stable/command-ref/nix-collect-garbage).

--- a/source/install-nix.md
+++ b/source/install-nix.md
@@ -81,5 +81,5 @@ $ nix --version
 nix (Nix) 2.11.0
 ```
 
-[multi-user installation]: https://nix.dev/manual/nix/2.18/installation/multi-user.html
-[single-user installation]: https://nix.dev/manual/nix/2.18/installation/single-user.html
+[multi-user installation]: https://nix.dev/manual/nix/stable/installation/multi-user.html
+[single-user installation]: https://nix.dev/manual/nix/stable/installation/single-user.html

--- a/source/reference/glossary.md
+++ b/source/reference/glossary.md
@@ -16,7 +16,7 @@ Nix language
 
     :::{seealso}
     - [](reading-nix-language)
-    - [Nix language reference](https://nix.dev/manual/nix/2.18/language)
+    - [Nix language reference](https://nix.dev/manual/nix/stable/language)
     :::
 
 Nix expression

--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -4,9 +4,9 @@
 
 Specifying remote Nix expressions, such as the one provided by Nixpkgs, can be done in several ways:
 
-- [`$NIX_PATH` environment variable](https://nix.dev/manual/nix/2.18/command-ref/env-common.html#env-NIX_PATH)
-- [`-I` option](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html#opt-I) to most of commands like `nix-build`, `nix-shell`, etc.
-- [`fetchurl`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchurl), [`fetchTarball`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchTarball), [`fetchGit`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchGit) or [Nixpkgs fetchers](https://nixos.org/manual/nixpkgs/stable/#chap-pkgs-fetchers) in Nix expressions
+- [`$NIX_PATH` environment variable](https://nix.dev/manual/nix/stable/command-ref/env-common.html#env-NIX_PATH)
+- [`-I` option](https://nix.dev/manual/nix/stable/command-ref/opt-common.html#opt-I) to most of commands like `nix-build`, `nix-shell`, etc.
+- [`fetchurl`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchurl), [`fetchTarball`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchTarball), [`fetchGit`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchGit) or [Nixpkgs fetchers](https://nixos.org/manual/nixpkgs/stable/#chap-pkgs-fetchers) in Nix expressions
 
 ## Possible URL values
 

--- a/source/tutorials/first-steps/ad-hoc-shell-environments.md
+++ b/source/tutorials/first-steps/ad-hoc-shell-environments.md
@@ -197,8 +197,8 @@ There are three things going on here:
 
 ## References
 
-- [Nix manual: `nix-shell`](https://nix.dev/manual/nix/2.18/command-ref/nix-shell) (or run `man nix-shell`)
-- [Nix manual: `-I` option](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html#opt-I)
+- [Nix manual: `nix-shell`](https://nix.dev/manual/nix/stable/command-ref/nix-shell) (or run `man nix-shell`)
+- [Nix manual: `-I` option](https://nix.dev/manual/nix/stable/command-ref/opt-common.html#opt-I)
 
 ## Next steps
 

--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -168,7 +168,7 @@ Exit the shell by typing `exit` or pressing `Ctrl`+`D`, then start it again with
 
 - [`mkShell` documentation](https://nixos.org/manual/nixpkgs/stable/#sec-pkgs-mkShell)
 - Nixpkgs [shell functions and utilities](https://nixos.org/manual/nixpkgs/stable/#ssec-stdenv-functions) documentation
-- [`nix-shell` documentation](https://nix.dev/manual/nix/2.18/command-ref/nix-shell)
+- [`nix-shell` documentation](https://nix.dev/manual/nix/stable/command-ref/nix-shell)
 
 ## Next steps
 

--- a/source/tutorials/first-steps/reproducible-scripts.md
+++ b/source/tutorials/first-steps/reproducible-scripts.md
@@ -47,10 +47,10 @@ It takes the following parameters relevant for our use case:
 - `-p` lists packages that should be present in the interpreter's environment
 - `-I` explicitly sets [the search path] for packages
 
-More details on the options can be found in the [`nix-shell` reference documentation](https://nix.dev/manual/nix/2.18/command-ref/nix-shell.html#options).
+More details on the options can be found in the [`nix-shell` reference documentation](https://nix.dev/manual/nix/stable/command-ref/nix-shell.html#options).
 
-[`nix-shell` as a shebang interpreter]: https://nix.dev/manual/nix/2.18/command-ref/nix-shell.html#use-as-a--interpreter
-[the search path]: https://nix.dev/manual/nix/2.18/command-ref/opt-common.html#opt-I
+[`nix-shell` as a shebang interpreter]: https://nix.dev/manual/nix/stable/command-ref/nix-shell.html#use-as-a--interpreter
+[the search path]: https://nix.dev/manual/nix/stable/command-ref/opt-common.html#opt-I
 
 Create a file named `nixpkgs-releases.sh` with the following content:
 
@@ -97,4 +97,4 @@ Run the script:
 
 - {ref}`reading-nix-language` to learn about the Nix language, which is used to declare packages and configurations.
 - {ref}`declarative-reproducible-envs` to create reproducible shell environments with a declarative configuration file.
-- [Garbage Collection](https://nix.dev/manual/nix/2.18/package-management/garbage-collection.html) – free up storage used by the programs made available through Nix
+- [Garbage Collection](https://nix.dev/manual/nix/stable/package-management/garbage-collection.html) – free up storage used by the programs made available through Nix

--- a/source/tutorials/module-system/a-basic-module/index.md
+++ b/source/tutorials/module-system/a-basic-module/index.md
@@ -71,7 +71,7 @@ The output of `evalModules` contains information about all evaluated modules, an
 :caption: default.nix
 ```
 
-Here's a helper script to parse and evaluate our `default.nix` file with [`nix-instantiate --eval`](https://nixos.org/manual/nix/stable/command-ref/nix-instantiate) and print the output as JSON:
+Here's a helper script to parse and evaluate our `default.nix` file with [`nix-instantiate --eval`](https://nix.dev/manual/nix/stable/command-ref/nix-instantiate) and print the output as JSON:
 
 ```{literalinclude} eval.bash
 :language: bash

--- a/source/tutorials/module-system/deep-dive.md
+++ b/source/tutorials/module-system/deep-dive.md
@@ -102,9 +102,9 @@ nix-instantiate --eval eval.nix -A config.scripts.output
 ```
 
 :::{dropdown} Detailed explanation
-[`nix-instantiate --eval`](https://nixos.org/manual/nix/stable/command-ref/nix-instantiate) parses and evaluates the Nix file at the specified path, and prints the result.
+[`nix-instantiate --eval`](https://nix.dev/manual/nix/stable/command-ref/nix-instantiate) parses and evaluates the Nix file at the specified path, and prints the result.
 `evalModules` produces an attribute set where the final configuration values appear in the `config` attribute.
-Therefore we evaluate the Nix expression in `eval.nix` at the [attribute path](https://nixos.org/manual/nix/stable/language/operators#attribute-selection) `config.scripts.output`.
+Therefore we evaluate the Nix expression in `eval.nix` at the [attribute path](https://nix.dev/manual/nix/stable/language/operators#attribute-selection) `config.scripts.output`.
 :::
 
 The error message indicates that the `scripts.output` option is used but not defined: a value must be set for the option before accessing it.

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -64,7 +64,7 @@ This tutorial *does not* explain all Nix language features in detail and *does n
 See the [Nix manual][manual-language] for a full language reference.
 :::
 
-[manual-language]: https://nix.dev/manual/nix/2.18/language/index.html
+[manual-language]: https://nix.dev/manual/nix/stable/language/index.html
 
 ### What do you need?
 
@@ -139,7 +139,7 @@ Type `:q` to exit [`nix repl`].
 
 :::
 
-[`nix repl`]: https://nix.dev/manual/nix/2.18/command-ref/new-cli/nix3-repl.html
+[`nix repl`]: https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-repl.html
 
 #### Evaluating Nix files
 
@@ -201,7 +201,7 @@ $ nix-instantiate --eval --strict file.nix
 
 :::
 
-[nix-instantiate]: https://nix.dev/manual/nix/2.18/command-ref/nix-instantiate.html
+[nix-instantiate]: https://nix.dev/manual/nix/stable/command-ref/nix-instantiate.html
 
 ### Notes on whitespace
 
@@ -314,8 +314,8 @@ Nix language data types *without functions* work just like their counterparts in
 - List elements are separated by white space.[^list-whitespace]
 :::
 
-[^attrnames]: Details: [Nix manual - attribute set](https://nix.dev/manual/nix/2.18/language/values.html#attribute-set)
-[^list-whitespace]: Details: [Nix manual - list](https://nix.dev/manual/nix/2.18/language/values.html#list)
+[^attrnames]: Details: [Nix manual - attribute set](https://nix.dev/manual/nix/stable/language/values.html#attribute-set)
+[^list-whitespace]: Details: [Nix manual - list](https://nix.dev/manual/nix/stable/language/values.html#list)
 
 (rec-attrset)=
 #### Recursive attribute set `rec { ... }`
@@ -971,9 +971,9 @@ For example, `<nixpkgs/lib>` points to the subdirectory `lib` of that file syste
 
 While you will encounter many such examples, we recommend to [avoid lookup paths](search-path) in production code, as they are [impurities](impurities) which are not reproducible.
 
-[NIX_PATH]: https://nix.dev/manual/nix/2.18/command-ref/env-common.html?highlight=nix_path#env-NIX_PATH
+[NIX_PATH]: https://nix.dev/manual/nix/stable/command-ref/env-common.html?highlight=nix_path#env-NIX_PATH
 [nixpkgs]: https://github.com/NixOS/nixpkgs
-[manual-primitives]: https://nix.dev/manual/nix/2.18/language/values.html#primitives
+[manual-primitives]: https://nix.dev/manual/nix/stable/language/values.html#primitives
 
 (indented-strings)=
 ### Indented strings
@@ -1480,7 +1480,7 @@ You need to know about both to understand and navigate Nix language code.
 
 We recommend to at least skim them to familiarise yourself with what is available.
 
-[operators]: https://nix.dev/manual/nix/2.18/language/operators.html
+[operators]: https://nix.dev/manual/nix/stable/language/operators.html
 
 (builtins)=
 ### `builtins`
@@ -1508,8 +1508,8 @@ builtins.toString
 <PRIMOP>
 ```
 
-[nix-operators]: https://nix.dev/manual/nix/2.18/language/operators.html
-[nix-builtins]: https://nix.dev/manual/nix/2.18/language/builtins.html
+[nix-operators]: https://nix.dev/manual/nix/stable/language/operators.html
+[nix-builtins]: https://nix.dev/manual/nix/stable/language/builtins.html
 
 (reading-nix-language-import)=
 #### `import`
@@ -1756,7 +1756,7 @@ The only way to specify build inputs in the Nix language is explicitly with:
 Nix and the Nix language refer to files by their content hash. If file contents are not known in advance, it's unavoidable to read files during expression evaluation.
 
 :::{note}
-Nix supports other types of impure expressions, such as [lookup paths](search-path) or the constant [`builtins.currentSystem`](https://nixos.org/manual/nix/stable/language/builtin-constants.html#builtins-currentSystem).
+Nix supports other types of impure expressions, such as [lookup paths](search-path) or the constant [`builtins.currentSystem`](https://nix.dev/manual/nix/stable/language/builtin-constants.html#builtins-currentSystem).
 We do not cover those here in more detail, as they do not matter for how the Nix language works in principle, and because they are discouraged for the very reason of breaking reproducibility.
 :::
 
@@ -1812,10 +1812,10 @@ Files to be used as build inputs do not have to come from the file system.
 
 The Nix language provides built-in impure functions to fetch files over the network during evaluation:
 
-- [`builtins.fetchurl`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchurl)
-- [`builtins.fetchTarball`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchTarball)
-- [`builtins.fetchGit`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchGit)
-- [`builtins.fetchClosure`](https://nix.dev/manual/nix/2.18/language/builtins.html#builtins-fetchClosure)
+- [`builtins.fetchurl`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchurl)
+- [`builtins.fetchTarball`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchTarball)
+- [`builtins.fetchGit`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchGit)
+- [`builtins.fetchClosure`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-fetchClosure)
 
 These functions evaluate to a file system path in the Nix store.
 
@@ -2030,7 +2030,7 @@ Explanation:
 - [Nixpkgs manual: Functions reference][nixpkgs-functions]
 - [Nixpkgs manual: Fetchers][nixpkgs-fetchers]
 
-[manual-string-interpolation]: https://nix.dev/manual/nix/2.18/language/string-interpolation.html
+[manual-string-interpolation]: https://nix.dev/manual/nix/stable/language/string-interpolation.html
 
 ## Next steps
 

--- a/source/tutorials/nixos/deploying-nixos-using-terraform.md
+++ b/source/tutorials/nixos/deploying-nixos-using-terraform.md
@@ -157,7 +157,7 @@ $ terraform apply
 ## Caveats
 
 - The `deploy_nixos` module requires NixOS to be installed on the target machine and Nix on the host machine.
-- The `deploy_nixos` module doesn't work when the client and target architectures are different (unless you use [distributed builds](https://nix.dev/manual/nix/2.18/advanced-topics/distributed-builds.html)).
+- The `deploy_nixos` module doesn't work when the client and target architectures are different (unless you use [distributed builds](https://nix.dev/manual/nix/stable/advanced-topics/distributed-builds.html)).
 - If you need to inject a value into Nix, there is no elegant solution.
 - Each machine is evaluated separately, so note that your memory requirements will grow linearly with the number of machines.
 

--- a/source/tutorials/nixos/nixos-configuration-on-vm.md
+++ b/source/tutorials/nixos/nixos-configuration-on-vm.md
@@ -13,7 +13,7 @@ Virtual machines are a practical tool for experimenting with or debugging NixOS 
 
 ## What do you need?
 
-- A working [Nix installation](https://nix.dev/manual/nix/2.18/installation/installation.html) on Linux, or [NixOS](https://nixos.org/manual/nixos/stable/index.html#sec-installation), with a graphical environment
+- A working [Nix installation](https://nix.dev/manual/nix/stable/installation/installation.html) on Linux, or [NixOS](https://nixos.org/manual/nixos/stable/index.html#sec-installation), with a graphical environment
 - Basic knowledge of the [Nix language](reading-nix-language)
 
 :::{important}
@@ -159,17 +159,17 @@ This command builds the attribute `vm` from the `nixos-23.11` release of NixOS, 
 
 ::::{dropdown} Detailed explanation
 
-- The positional argument to [`nix-build`](https://nix.dev/manual/nix/2.18/command-ref/nix-build.html) is a path to the derivation to be built.
+- The positional argument to [`nix-build`](https://nix.dev/manual/nix/stable/command-ref/nix-build.html) is a path to the derivation to be built.
   That path can be obtained from [a Nix expression that evaluates to a derivation](derivations).
 
   The virtual machine build helper is defined in NixOS, which is part of the [`nixpkgs` repository](https://github.com/NixOS/nixpkgs).
   Therefore we use the [lookup path](lookup-path-tutorial) `<nixpkgs/nixos>`.
 
-- The [`-A` option](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html#opt-attr) specifies the attribute to pick from the provided Nix expression `<nixpkgs/nixos>`.
+- The [`-A` option](https://nix.dev/manual/nix/stable/command-ref/opt-common.html#opt-attr) specifies the attribute to pick from the provided Nix expression `<nixpkgs/nixos>`.
 
   To build the virtual machine, we choose the `vm` attribute as defined in [`nixos/default.nix`](https://github.com/NixOS/nixpkgs/blob/7c164f4bea71d74d98780ab7be4f9105630a2eba/nixos/default.nix#L19).
 
-- The [`-I` option](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html#opt-I) prepends entries to the search path.
+- The [`-I` option](https://nix.dev/manual/nix/stable/command-ref/opt-common.html#opt-I) prepends entries to the search path.
 
   Here we set `nixpkgs` to refer to a [specific version of Nixpkgs](ref-pinning-nixpkgs) and set `nix-config` to the `configuration.nix` file in the current directory.
 
@@ -363,9 +363,9 @@ The NixOS manual has chapters on [X11](https://nixos.org/manual/nixos/stable/#se
 - [NixOS Manual: Changing the configuration](https://nixos.org/manual/nixos/stable/#sec-changing-config).
 - [NixOS source code: `configuration template` in `tools.nix`](https://github.com/NixOS/nixpkgs/blob/4e0525a8cdb370d31c1e1ba2641ad2a91fded57d/nixos/modules/installer/tools/tools.nix#L122-L226).
 - [NixOS source code: `vm` attribute in `default.nix`](https://github.com/NixOS/nixpkgs/blob/master/nixos/default.nix).
-- [Nix manual: `nix-build`](https://nix.dev/manual/nix/2.18/command-ref/nix-build.html).
-- [Nix manual: common command-line options](https://nix.dev/manual/nix/2.18/command-ref/opt-common.html).
-- [Nix manual: `NIX_PATH` environment variable](https://nix.dev/manual/nix/2.18/command-ref/env-common.html#env-NIX_PATH).
+- [Nix manual: `nix-build`](https://nix.dev/manual/nix/stable/command-ref/nix-build.html).
+- [Nix manual: common command-line options](https://nix.dev/manual/nix/stable/command-ref/opt-common.html).
+- [Nix manual: `NIX_PATH` environment variable](https://nix.dev/manual/nix/stable/command-ref/env-common.html#env-NIX_PATH).
 - [QEMU User Documentation](https://www.qemu.org/docs/master/system/qemu-manpage.html) for more runtime options
 - [NixOS option search: `virtualisation.qemu`](https://search.nixos.org/options?query=virtualisation.qemu) for declarative virtual machine configuration
 

--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -15,7 +15,7 @@ But when *first* packaging existing software with Nix, it's common to encounter 
 
 ## Introduction
 
-In this tutorial, you'll create your first [Nix derivations](https://nix.dev/manual/nix/2.18/language/derivations) to package C/C++ software, taking advantage of the [Nixpkgs Standard Environment](https://nixos.org/manual/nixpkgs/stable/#part-stdenv) (`stdenv`), which automates much of the work involved.
+In this tutorial, you'll create your first [Nix derivations](https://nix.dev/manual/nix/stable/language/derivations) to package C/C++ software, taking advantage of the [Nixpkgs Standard Environment](https://nixos.org/manual/nixpkgs/stable/#part-stdenv) (`stdenv`), which automates much of the work involved.
 
 ### What will you learn?
 
@@ -108,7 +108,7 @@ error: cannot evaluate a function that has an argument without a value ('stdenv'
        Nix attempted to evaluate a function as a top level expression; in
        this case it must have its arguments supplied either by default
        values, or passed explicitly with '--arg' or '--argstr'. See
-       https://nixos.org/manual/nix/stable/language/constructs.html#functions.
+       https://nix.dev/manual/nix/stable/language/constructs.html#functions.
 
        at /home/nix-user/hello.nix:3:3:
 

--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -1,8 +1,8 @@
 (file-sets-tutorial)=
 # Working with local files
 
-To build a local project in a Nix derivation, source files must be accessible to its [`builder` executable](https://nixos.org/manual/nix/stable/language/derivations#attr-builder).
-Since by default, the `builder` runs in an [isolated environment](https://nixos.org/manual/nix/stable/command-ref/conf-file.html#conf-sandbox) that only allows reading from the Nix store, the Nix language has built-in features to copy local files to the store and expose the resulting store paths.
+To build a local project in a Nix derivation, source files must be accessible to its [`builder` executable](https://nix.dev/manual/nix/stable/language/derivations#attr-builder).
+Since by default, the `builder` runs in an [isolated environment](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-sandbox) that only allows reading from the Nix store, the Nix language has built-in features to copy local files to the store and expose the resulting store paths.
 
 Using these features directly can be tricky however:
 
@@ -11,7 +11,7 @@ Using these features directly can be tricky however:
   Furthermore, it always adds the entire directory to the store, including unneeded files,
   which causes unnecessary new builds when they change.
 
-- The [`builtins.path`](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-path) function
+- The [`builtins.path`](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-path) function
   (and equivalently [`lib.sources.cleanSourceWith`](https://nixos.org/manual/nixpkgs/stable/#function-library-lib.sources.cleanSourceWith))
   can address these problems.
   However, it's often hard to express the desired path selection using the `filter` function interface.
@@ -24,7 +24,7 @@ It abstracts over built-in functionality and offers a safer and more convenient 
 A _file set_ is a data type representing a collection of local files.
 File sets can be created, composed, and manipulated with the various functions of the library.
 
-You can explore and learn about the library with [`nix repl`](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-repl):
+You can explore and learn about the library with [`nix repl`](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-repl):
 
 ```shell-session
 $ nix repl -f channel:nixos-23.11
@@ -40,7 +40,7 @@ trace: /home/user (all files in directory)
 null
 ```
 
-All functions that expect a file set for an argument can also accept a [path](https://nixos.org/manual/nix/stable/language/values#type-path).
+All functions that expect a file set for an argument can also accept a [path](https://nix.dev/manual/nix/stable/language/values#type-path).
 Such path arguments are then [implicitly turned into sets](https://nixos.org/manual/nixpkgs/stable/#sec-fileset-path-coercion) that contain _all_ files under the given path.
 In the previous trace this is indicated by `(all files in directory)`.
 
@@ -63,7 +63,7 @@ This is in contrast to coercion of paths to strings such as in `"${./.}"`,
 which copies the whole directory to the Nix store on evaluation!
 
 :::{warning}
-When using the [`flakes` and `nix-command` experimental features](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake),
+When using the [`flakes` and `nix-command` experimental features](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake),
 a local directory within a Flake is always copied into the Nix store *completely* unless it is a Git repository!
 :::
 
@@ -79,7 +79,7 @@ trace: /home/user
 trace: - some-file (regular)
 ```
 
-In addition to the included file, this also prints its [file type](https://nixos.org/manual/nix/stable/language/builtins.html#builtins-readFileType).
+In addition to the included file, this also prints its [file type](https://nix.dev/manual/nix/stable/language/builtins.html#builtins-readFileType).
 
 
 ## Example project
@@ -553,7 +553,7 @@ this derivation will be built:
 This includes too much though, as not all of these files are needed to build the derivation as originally intended.
 
 :::{note}
-When using the [`flakes` and `nix-command` experimental features](https://nixos.org/manual/nix/stable/command-ref/new-cli/nix3-flake),
+When using the [`flakes` and `nix-command` experimental features](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-flake),
 this function isn't needed, because `nix build` by default only allows access to files tracked by Git.
 However, in order to provide the same developer experience for stable Nix, use of this function is nevertheless recommended.
 :::


### PR DESCRIPTION
1. A small fixup/typo over an older reference to `niv`;
2. `niv` is not exactly unmaintained - the most recent commit is from less than 2 months ago. Let's rewrite this in a more neutral manner.