### PR TITLE
Update working-with-local-files.md

### DIFF
--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -375,7 +375,7 @@ Create a file set containing a union of the files to exclude (`fs.unions [ ... ]
         (fs.maybeMissing ./result)
         ./default.nix
         ./build.nix
-        ./nix
+        ./npins
       ]);
 ```
 
@@ -518,7 +518,7 @@ Create a local Git repository and add all files except `src/select.o` and `./res
 $ git init
 Initialized empty Git repository in /home/user/fileset/.git/
 $ git add -A
-$ git reset src/select.o result
+$ git reset src/select.c result
 ```
 
 Re-use this selection of files with `gitTracked`:


### PR DESCRIPTION
Hi first contribution here,


fixed typos pointed out by @biscotty666  in Issue #1002

line 378 ./nix -> ./npins


```
:caption: build.nix
  sourceFiles =
    fs.difference
      ./.
      (fs.unions [
        (fs.maybeMissing ./result)
        ./default.nix
        ./build.nix
        ./npins
      ]);

```


line 521 src/select.o -> src/select.c

```
$ git init
Initialized empty Git repository in /home/user/fileset/.git/
$ git add -A
$ git reset src/select.c result
```

I hope this fixes the typos.