### PR TITLE
fix mkShellNoCC to use `packages` instead of `buildInputs`

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1936,7 +1936,7 @@ let
   message = "hello world";
 in
 pkgs.mkShellNoCC {
-  buildInputs = with pkgs; [ cowsay ];
+  packages = with pkgs; [ cowsay ];
   shellHook = ''
     cowsay ${message}
   '';
@@ -1953,7 +1953,7 @@ Explanation:
 - The name `message` is bound to the string value `"hello world"`.
 - The attribute `mkShellNoCC` of the `pkgs` set is a function that is passed an attribute set as argument.
   Its return value is also the result of the outer function.
-- The attribute set passed to `mkShellNoCC` has the attributes `buildInputs` (set to a list with one element: the `cowsay` attribute from `pkgs`) and `shellHook` (set to an indented string).
+- The attribute set passed to `mkShellNoCC` has the attributes `packages` (set to a list with one element: the `cowsay` attribute from `pkgs`) and `shellHook` (set to an indented string).
 - The indented string contains an interpolated expression, which will expand the value of `message` to yield `"hello world"`.
 
 


### PR DESCRIPTION
According to:
https://github.com/NixOS/nix.dev/blob/cdd059f7e5627b68a137d4de3ea98ab100bdb5a9/source/tutorials/first-steps/declarative-shell.md?plain=1#L84

>The `packages` attribute argument to `mkShellNoCC` is simply an alias for `nativeBuildInputs`.

I believe https://github.com/NixOS/nix.dev/issues/131 can be closed now. I think this is one of the last remaining instances where mkShell* uses `buildInputs`.