### PR TITLE
Update packaging-existing-software.md

### DIFF
--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -129,7 +129,7 @@ The recommended way to do this is to create a `default.nix` file in the same dir
 ```nix
 # default.nix
 let
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-22.11";
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 {

--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -237,7 +237,7 @@ Change the `default.nix` from the previous section by adding a new attribute for
 ```nix
 # default.nix
 let
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-22.11";
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/nixos-24.05";
   pkgs = import nixpkgs { config = {}; overlays = []; };
 in
 {


### PR DESCRIPTION
update version of nixpkgs used to avoid multiple-hour cache build for first-time users trying to learn Nix