### PR TITLE
Update towards-reproducibility-pinning-nixpkgs.md

### DIFF
--- a/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
@@ -2,13 +2,17 @@
 
 # Towards reproducibility: pinning Nixpkgs
 
-In various Nix examples, you'll often see references to [\<nixpkgs>](https://github.com/NixOS/nixpkgs), as follows.
+In various Nix examples, you'll often see the following:
 
 ```nix
 { pkgs ? import <nixpkgs> {} }:
 
 ...
 ```
+
+:::{note}
+`<nixpkgs>` points to the file system path of some revision of {term}`Nixpkgs`. See [lookup paths](../nix-language.md#lookup-paths) in the next chapter, [](../nix-language.md).
+:::
 
 This is a **convenient** way to quickly demonstrate a Nix expression and get it working by importing Nix packages.
 

--- a/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
@@ -12,7 +12,7 @@ In various Nix examples, you'll often see the following:
 
 :::{note}
 `<nixpkgs>` points to the file system path of some revision of {term}`Nixpkgs`.
-Find more information on [lookup paths](../nix-language.md#lookup-paths) in [](../nix-language.md).
+Find more information on [lookup paths](lookup-path-tutorial) in [](reading-nix-language).
 :::
 
 This is a **convenient** way to quickly demonstrate a Nix expression and get it working by importing Nix packages.

--- a/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
+++ b/source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
@@ -11,7 +11,8 @@ In various Nix examples, you'll often see the following:
 ```
 
 :::{note}
-`<nixpkgs>` points to the file system path of some revision of {term}`Nixpkgs`. See [lookup paths](../nix-language.md#lookup-paths) in the next chapter, [](../nix-language.md).
+`<nixpkgs>` points to the file system path of some revision of {term}`Nixpkgs`.
+Find more information on [lookup paths](../nix-language.md#lookup-paths) in [](../nix-language.md).
 :::
 
 This is a **convenient** way to quickly demonstrate a Nix expression and get it working by importing Nix packages.


### PR DESCRIPTION
I expected the `<nixpkgs>` link to point to a resource that explains what that construct is and not directly to Nixpkgs. If I would be totally new to Nix, that would be even more confusing.

Couldn't test whether the links in the new note section resolve properly as MyST wouldn't compile on my Mac M1. If you you like this change, I can spend more time to test them properly.