### PR TITLE
make building the manuals optional

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     - name: Build
       run: |
-        nix-build
+        nix-build --arg withManuals true
 
         # The netlify action doesn't follow symlinks properly.
         mkdir ./dist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,16 @@ To manually test [redirects](./_redirects):
 [nix-shell:nix.dev]$ netlify dev -d result
 ```
 
+## Building the reference manuals
+
+By default nix.dev builds without the various versions of the Nix reference manual, as that takes quite a while due to how it's currently implemented.
+To enable building the manuals:
+
+```shell-session
+[nix-shell:nix.dev]$ nix-build -A build --arg withManuals true
+[nix-shell:nix.dev]$ devmode --arg withManuals true
+```
+
 ## Updating reference manuals
 
 With the current setup, the [Nix manual hosted on nix.dev](https://nix.dev/reference/nix-manual) does not get updated automatically with new releases.


### PR DESCRIPTION
since we currently can't fetch the manuals as a tarball from Hydra, we
have to evaluate all the Nix releases under the sun, which takes quite
a while. most of the time this is not needed and is in the way to work
on the site, so disable it by default.