### PR TITLE
Remove `inputsFrom` from shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -116,7 +116,6 @@ in
   build = nix-dev;
 
   shell = pkgs.mkShell {
-    inputsFrom = [ nix-dev ];
     packages = [
       devmode
       update-nix-releases


### PR DESCRIPTION
`.shell` takes unusually long to evaluate because `.build` includes
multiple nixpkgses. This solves that problem,
at the cost of not being able to run `make html` at the shell.
This may be acceptable, because `make html` produces an incomplete
yet somewhat useful nix.dev.
We would assume that most if not all contributors would run `devmode`
in the shell and not `make html` because that has added convenience
and produces the complete nix.dev.
At the risk of heresy, I would mention that with a flake we'd have
enjoyed evaluation cache.

Co-authored-by: ruben <ruben.beck@pm.me>
Co-authored-by: kurogeek <panupong.jtp@gmail.com>
Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>
Co-authored-by: warren2k <846021+warren2k@users.noreply.github.com>
