### PR TITLE
add admonitions for macOS 15 Sequoia update

### DIFF
--- a/source/install-nix.md
+++ b/source/install-nix.md
@@ -18,6 +18,14 @@ On Arch Linux, you can alternatively [install Nix through `pacman`](https://wiki
 
 ::::{tab-item} macOS
 
+> **Updating to macOS 15 Sequoia**
+>
+> If you recently updated to macOS 15 Sequoia and are getting
+> ```console
+> error: the user '_nixbld1' in the group 'nixbld' does not exist
+> ```
+> when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
+
 Install Nix via the recommended [multi-user installation]:
 
 ```shell-session

--- a/source/install-nix.md
+++ b/source/install-nix.md
@@ -18,19 +18,21 @@ On Arch Linux, you can alternatively [install Nix through `pacman`](https://wiki
 
 ::::{tab-item} macOS
 
-> **Updating to macOS 15 Sequoia**
->
-> If you recently updated to macOS 15 Sequoia and are getting
-> ```console
-> error: the user '_nixbld1' in the group 'nixbld' does not exist
-> ```
-> when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
-
 Install Nix via the recommended [multi-user installation]:
 
 ```shell-session
 $ curl -L https://nixos.org/nix/install | sh
 ```
+
+:::{important}
+**Updating to macOS 15 Sequoia**
+
+If you recently updated to macOS 15 Sequoia and are getting
+```console
+error: the user '_nixbld1' in the group 'nixbld' does not exist
+```
+when running Nix commands, refer to GitHub issue [NixOS/nix#10892](https://github.com/NixOS/nix/issues/10892) for instructions to fix your installation without reinstalling.
+:::
 
 ::::
 


### PR DESCRIPTION
Same premise/language as https://github.com/NixOS/nix/pull/11487

The impending release of macOS 15 Sequoia will break many existing nix installs on macOS, which may lead to an increased number of people who are looking to try to reinstall Nix without noticing the open/pinned issue (NixOS#10892) that explains the problem and outlines how to migrate existing installs.

These admonitions are a short-term measure until we are over the hump and support volumes dwindle.