### PR TITLE
Add garnix to alternatives

### DIFF
--- a/source/tutorials/nixos/distributed-builds-setup.md
+++ b/source/tutorials/nixos/distributed-builds-setup.md
@@ -318,6 +318,7 @@ Add all new remote builders to the `nix.buildMachines` attribute shown in the []
 
 - [nixbuild.net](https://nixbuild.net) - Nix remote builders as a service
 - [Hercules CI](https://hercules-ci.com/) - Continuous integration with automatic build distribution
+- [garnix](https://garnix.io/) - Hosted continuous integration with build distribution
 
 ## References
 


### PR DESCRIPTION
Added garnix to the alternatives, beside nix.build and Hercules.

Disclaimer: I started garnix. I also read the discussion [here](https://github.com/NixOS/nix.dev/pull/694), and generally agree with limiting the amount of space dedicated to commercial services, and don't want to discourage that goal. But this seems like the limited mention that people settled on as being okay, and moreover is exactly in line with the usage in this section, so it seemed to me like a reasonably contribution.