### PR TITLE
typo: no folder named 'nix' in this example

### DIFF
--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -422,7 +422,7 @@ Use it to select all files with a name ending in `.nix`:
 -        ./default.nix
 -        ./build.nix
 +        (fs.fileFilter (file: file.hasExt "nix") ./.)
-         ./nix
+         ./npins
        ]);
 ```
 


### PR DESCRIPTION
Should be './npins' folder instead of './nix' for coherence