### PR TITLE
Update nix repl syntax in cross-compilation page

### DIFF
--- a/source/tutorials/cross-compilation.md
+++ b/source/tutorials/cross-compilation.md
@@ -86,7 +86,7 @@ It's only possible to cross compile between `aarch64-darwin` and `x86_64-darwin`
 It is possible to explore them in `nix repl`:
 
 :::{note}
-Later versions of `nix repl` require `-f` flag:
+[Starting with Nix 2.19](https://nix.dev/manual/nix/latest/release-notes/rl-2.19), `nix repl` requires the `-f` / `--file` flag:
 ```shell-session
 $ nix repl -f '<nixpkgs>' -I nixpkgs=channel:nixos-23.11
 ```

--- a/source/tutorials/cross-compilation.md
+++ b/source/tutorials/cross-compilation.md
@@ -85,6 +85,13 @@ It's only possible to cross compile between `aarch64-darwin` and `x86_64-darwin`
 
 It is possible to explore them in `nix repl`:
 
+:::{note}
+Later versions of `nix repl` require `-f` flag:
+```shell-session
+$ nix repl -f '<nixpkgs>' -I nixpkgs=channel:nixos-23.11
+```
+:::
+
 ```shell-session
 $ nix repl '<nixpkgs>' -I nixpkgs=channel:nixos-23.11
 Welcome to Nix 2.18.1. Type :? for help.


### PR DESCRIPTION
- Closes #1054 
- Add a note explaining that later versions of `nix repl` require the `-f` flag
- Maintain the original example for compatibility with older versions