### PR TITLE
Added extra context in the nested string interpolation example 

### DIFF
--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -803,8 +803,7 @@ error: cannot coerce an integer to a string
             5|
 ```
 
-Interpolated expressions can be arbitrarily nested.
-
+Interpolated expressions can be arbitrarily nested. Note that the `+` sign in the following example is the concatenation operator which is taking a string as its second argument.
 (This can become hard to read, and we recommend to avoid it in practice.)
 
 Example:

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -1767,10 +1767,11 @@ For historical reasons, some of the functions in `pkgs.lib` are equivalent to [`
 So far we have only covered what we call *pure expressions*:
 declaring data and transforming it with functions.
 
-In practice, describing derivations requires observing the outside world.
+In practice, describing derivations requires observing the outside world. Recall that derivations are
+precise descriptions of how contents of existing files are used to derive new files.  We discuss [](derivations)futher in the tuturial.
 
 There is only one impurity in the Nix language that is relevant here:
-reading files from the file system as *build inputs*
+reading files from the file system as *build inputs*.
 
 Build inputs are files that derivations refer to in order to describe how to derive new files.
 When run, a derivation will only have access to explicitly declared build inputs.
@@ -1778,7 +1779,7 @@ When run, a derivation will only have access to explicitly declared build inputs
 The only way to specify build inputs in the Nix language is explicitly with:
 
 - File system paths
-- Dedicated functions.
+- Dedicated functions
 
 Nix and the Nix language refer to files by their content hash. If file contents are not known in advance, it's unavoidable to read files during expression evaluation.
 

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -803,7 +803,8 @@ error: cannot coerce an integer to a string
             5|
 ```
 
-Interpolated expressions can be arbitrarily nested. Note that the `+` sign in the following example is the concatenation operator which is taking a string as its second argument.
+Interpolated expressions can be arbitrarily nested.
+
 (This can become hard to read, and we recommend to avoid it in practice.)
 
 Example:

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -823,7 +823,14 @@ in
 ```
 
 :::{dropdown} Detailed explanation
-The `+` sign in the above expression is the concatenation operator. It is one of the many [built-in operators][operators] (`+`, `==`, `&&`, etc.) These operators can be used within `${ }`.
+Any Nix expression where the value can be represented as a string can be used within `${ }`.
+
+The `+` sign in the above expression is the [string concatenation operator](https://nix.dev/manual/nix/latest/language/operators#string-concatenation), which takes two strings and produces a new string.
+
+The expression in the example is deliberately confusing in order to demonstrate that arbitrarily nested string interpolations are possible, but tend to be hard to read.
+
+It denotes a string that contains the interpolation of concatenating the value of `a` with a string that starts with a space and is followed by another interpolated string.
+That second interpolated string is again the result of concatenating the value of `a` and yet another string that starts with a space and is followed by an interpolation of `a`.
 
 Example:
 ```{code-block} nix

--- a/source/tutorials/nix-language.md
+++ b/source/tutorials/nix-language.md
@@ -822,6 +822,26 @@ in
 "no no no"
 ```
 
+:::{dropdown} Detailed explanation
+The `+` sign in the above expression is the concatenation operator. It is one of the many [built-in operators][operators] (`+`, `==`, `&&`, etc.) These operators can be used within `${ }`.
+
+Example:
+```{code-block} nix
+:class: expression
+let
+  a = "one";
+  b = "two";
+in
+"${a + b}"
+```
+
+```{code-block}
+:class: value
+"onetwo"
+```
+
+Built-in functions are discussed in a [later section](libraries).
+:::
 
 :::{warning}
 You may encounter strings that use the dollar sign (`$`) before an assigned name, but no braces (`{ }`):


### PR DESCRIPTION
the string + operator was not previously introduced and it wasn't clear that you can have more than just a variable within ${}
im doing a video series for learning the nix programming language and when i saw this part of the language tutorial, i had a hard time parsing what i was seeing. perhaps this could make it more clear. thank you! 