### PR TITLE
add `nix-serve-ng` as an alternative to set up HTTP caches

### DIFF
--- a/source/tutorials/nixos/binary-cache-setup.md
+++ b/source/tutorials/nixos/binary-cache-setup.md
@@ -221,6 +221,8 @@ To save storage space, please refer to the following NixOS configuration attribu
 
 ## Alternatives
 
+- [`nix-serve-ng`](https://github.com/aristanetworks/nix-serve-ng): A drop-in replacement for `nix-serve`, written in Haskell
+
 - The [SSH Store](https://nix.dev/manual/nix/latest/store/types/ssh-store), [Experimental SSH Store](https://nix.dev/manual/nix/latest/store/types/experimental-ssh-store), and the [S3 Binary Cache Store](https://nix.dev/manual/nix/latest/store/types/s3-binary-cache-store) can also be used to serve a cache.
   There are many commercial providers for S3-compatible storage, for example:
   - Amazon S3


### PR DESCRIPTION
@Gabriella439 I did consider making it the default in the tutorial instead of adding yet another alternative to the list. What do you think?