### PR TITLE
Add troubleshooting entry for Nix issue on macOS

### DIFF
--- a/source/guides/troubleshooting.md
+++ b/source/guides/troubleshooting.md
@@ -51,9 +51,13 @@ This may mean you are trying to import a too large file or directory into the [N
 
 Try to reduce the size of the directory to import, or run [garbage collection](https://nix.dev/manual/nix/stable/command-ref/nix-collect-garbage).
 
-## Darwin update breaks Nix installation
+## macOS update breaks Nix installation
 
-This is a known [issue](https://github.com/NixOS/nix/issues/3616). Add the following code snippet to the end of the configuration file `/etc/zshrc` and restart the shell:
+This is a [known issue](https://github.com/NixOS/nix/issues/3616).
+The [Nix installer](https://nix.dev/manual/nix/latest/installation/installing-binary) modifies `/etc/zshrc`.
+When macOS is updated, it will typically overwrite `/etc/zshrc` again.
+
+As a workaround, add the following code snippet to the end of `/etc/zshrc` and restart the shell:
 
 ```bash
 if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then

--- a/source/guides/troubleshooting.md
+++ b/source/guides/troubleshooting.md
@@ -50,3 +50,13 @@ $ nix-store --load-db < /tmp/db.dump
 This may mean you are trying to import a too large file or directory into the [Nix store](https://nix.dev/manual/nix/stable/glossary#gloss-store), or your machine is running out of resources, such as disk space or memory.
 
 Try to reduce the size of the directory to import, or run [garbage collection](https://nix.dev/manual/nix/stable/command-ref/nix-collect-garbage).
+
+## Darwin update breaks Nix installation
+
+This is a known [issue](https://github.com/NixOS/nix/issues/3616). Add the following code snippet to the end of the configuration file `/etc/zshrc` and restart the shell:
+
+```bash
+if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+  . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+fi
+```


### PR DESCRIPTION
In spite not being too much of an issue, Nix users on Darwin have the recurrent problem of macOS [updates breaking Nix](https://gist.github.com/meeech/0b97a86f235d10bc4e2a1116eec38e7e).

It might be helpful to have it documented, even if temporarly, here until the [Nix installer workaround](https://github.com/NixOS/nix/pull/9243) gets merged.