### PR TITLE
updated pinning-nixpkgs.md to have info on how to get the commits and channel names to use

### DIFF
--- a/source/reference/pinning-nixpkgs.md
+++ b/source/reference/pinning-nixpkgs.md
@@ -77,3 +77,8 @@ Specifying remote Nix expressions, such as the one provided by Nixpkgs, can be d
     pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/nixos-22.11.tar.gz") {};
   in pkgs.stdenv.mkDerivation { ... }
   ```
+## Finding specific commits and releases
+The latest commit that has passed tests for each release, and also a list of channel names are available at [status.nixos.org](https://status.nixos.org/).
+The commit can be used when pinning to a specific commit and the channel name can be used when pinning to the latest channel version.
+
+The official channels list is available at [nixos.org/channels](https://nixos.org/channels).


### PR DESCRIPTION
i went through first steps, then the language basics. at the end of language basics it had some next steps which took me back to declarative shell evironments. first time around, i didnt pay attention to specifics because i didn't know the language yet. this time around, i expected to understand it fully. 

i noticed the fetchTarball url https://github.com/NixOS/nixpkgs/tarball/nixos-24.05 and also the url in the detailed description https://github.com/NixOS/nixpkgs/tarball/2a601aafdc5605a5133a2ca506a34a3a73377247.

i had no idea how to create these. the detailed description has a link to ref-pinning-nixpkgs but this doesn't talk about how to find the commit to use. 
i thought it would be useful to add that information.

The next section towards-reproducibility-pinning-nixpkgs does discuss pinning to specific commits which would have been helpful to link to, but i think adding this to the manual would help more paths because even the towards-reproducibility-pinning-nixpkgs document references the manual.

