### PR TITLE
distributed builds: use stdenv.hostPlatform.system

### DIFF
--- a/source/tutorials/nixos/distributed-builds-setup.md
+++ b/source/tutorials/nixos/distributed-builds-setup.md
@@ -187,7 +187,7 @@ If your *local machine* runs NixOS, in its configuration directory create the fi
       hostName = "remotebuilder";
       sshUser = "remotebuild";
       sshKey = "/root/.ssh/remotebuild";
-      system = pkgs.stdenv.hostPlatform;
+      system = pkgs.stdenv.hostPlatform.system;
       supportedFeatures = [ "nixos-test" "big-parallel" "kvm" ];
     }
   ];


### PR DESCRIPTION
hostPlatform alone returns an attribute set, but that setting expects a system type string