### PR TITLE
Add missing word in callpackage.md

### DIFF
--- a/source/tutorials/callpackage.md
+++ b/source/tutorials/callpackage.md
@@ -171,7 +171,7 @@ Add a third attribute `hello-folks` to `default.nix` and set it to `hello.overri
 
 :::{note}
 The resulting attribute set is now recursive (by the keyword `rec`).
-That is, attribute values can refer to names from within the same attribute.
+That is, attribute values can refer to names from within the same attribute set.
 :::
 
 `override` passes `audience` to the original function in `hello.nix` - it *overrides* whatever arguments have been passed in the original `callPackage` that produced the derivation `hello`.


### PR DESCRIPTION
I believe there's a missing `set` at the end of this note for it to make sense:

```
The resulting attribute set is now recursive (by the keyword rec). That is, attribute values can refer to names from within the same attribute [set].
```