### PR TITLE
Fix wrong use of ? quantifier in regex

### DIFF
--- a/source/tutorials/module-system/deep-dive.md
+++ b/source/tutorials/module-system/deep-dive.md
@@ -1149,7 +1149,7 @@ Add a new `colorType` block to `path.nix`, specifying the allowed color names an
 
 +  # Either a color name, `0xRRGGBB` or `0xRRGGBBAA`
 +  colorType = lib.types.either
-+    (lib.types.strMatching "0x[0-9A-F]{6}[0-9A-F]{2}?")
++    (lib.types.strMatching "0x[0-9A-F]{6}([0-9A-F]{2})?")
 +    (lib.types.enum [
 +      "black" "brown" "green" "purple" "yellow"
 +      "blue" "gray" "orange" "red" "white"


### PR DESCRIPTION
The Regex format is wrong, it wants to say that the last two components (AA) are optional, but that needs a n optional group. At least for me on lix - but this also rhymes with my understanding of regexes.

```bash
❯ nix --version
nix (Lix, like Nix) 2.92.0
System type: aarch64-darwin
Additional system types: aarch64-darwin, x86_64-darwin
Features: gc, signed-caches
System configuration file: /etc/nix/nix.conf
User configuration files: /Users/dwt/.config/nix/nix.conf:/Users/dwt/.nix-profile/etc/xdg/nix/nix.conf:/run/current-system/sw/etc/xdg/nix/nix.conf:/nix/var/nix/profiles/default/etc/xdg/nix/nix.conf
Store directory: /nix/store
State directory: /nix/var/nix
Data directory: /nix/store/jgg7r6y6zz7lj84n1x4l8g8n25n3mpky-lix-2.92.0/share
```