### PR TITLE
_redirects: Fix /manual/nix/development redirect

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -34,6 +34,6 @@
 
 /permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301
 /manual/nix /reference/nix-manual 200
-/manual/nix/unstable/* https://hydra.nixos.org/job/nix/master/build.nix.x86_64-linux/latest/download/1/manual/:splat 200
-/manual/nix/development/* https://hydra.nixos.org/job/nix/master/build.nix.x86_64-linux/latest/download/1/manual/:splat 200
+/manual/nix/unstable/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
+/manual/nix/development/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
 /tutorials/nixos/continuous-integration-github-actions /guides/recipes/continuous-integration-github-actions 301


### PR DESCRIPTION
This makes the `/manual/nix/development/` redirect point to the latest build again. The `nix` package does not list the manual as a hydra build product anymore since it has become a link farm and/or multi-derivation package.