### PR TITLE
Add note about xz requirement for tarball in install-nix.md

### DIFF
--- a/source/install-nix.md
+++ b/source/install-nix.md
@@ -1,6 +1,8 @@
 (install-nix)=
 
 # Install Nix
+Requirements:
+ - Prior to installation, you might need to first install `xz-utils` or similar for uncompressing the Nix binary tarball (`.tar.xz`) that will be downloaded via the scripts below.
 
 :::::{tab-set}
 


### PR DESCRIPTION
Since we're providing for download `.tar.xz` binary tarballs, we assume that systems have xz-utils or similar for handling that compression format.  We should make a note of this small requirement at the beginning of the Install Nix page.

Ref for WSL :
```
PS C:\Users\thadg> wsl
thad@MarsOrBust:/mnt/c/Users/thadg$ curl -L https://nixos.org/nix/install | sh -s -- --daemon
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:--  0:00:03 --:--:--     0
100  4267  100  4267    0     0    880      0  0:00:04  0:00:04 --:--:--  5216
sh: you do not have 'xz' installed, which I need to unpack the binary tarball
```

Fixed after running `sudo apt install xz-utils` for my Debian distribution with WSL