### PR TITLE
Remove vestigial reference to the Magic Nix Cache Action.

### DIFF
--- a/source/guides/recipes/continuous-integration-github-actions.md
+++ b/source/guides/recipes/continuous-integration-github-actions.md
@@ -15,7 +15,7 @@ One benefit of Nix is that **CI can build and cache developer environments for e
 
 An important aspect of CI is the feedback loop of, **how many minutes does the build take to finish?**
 
-There are a several good options, but Cachix (below) and integrating with GitHub's built-in cache (at the end) are the most straightforward.
+There are a several good options, but Cachix (below) is the most straightforward.
 
 ## Caching builds using Cachix
 


### PR DESCRIPTION
We removed the documentation about Magic Nix Cache Action in https://github.com/nixos/nix.dev/commit/e779898888db5b780882c9867e528cbce30ac1c1, but didn't remove this tantalizing reference to it. (At least, I think that's what this comment is about.)