### PR TITLE
Update nix-build output in packaging-existing-software.md, update port in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Enter the development environment with `nix-shell`, or [set up direnv](https://n
 [nix-shell:nix.dev]$ devmode
 ```
 
-and open a browser at <http://localhost:5500>.
+and open a browser at <http://localhost:8080>.
 
 As you make changes, your browser should auto-reload.
 

--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -150,21 +150,10 @@ Now run the `nix-build` command with the new argument:
 
 ```console
 $ nix-build -A hello
-error:
-...
-       … while evaluating attribute 'src' of derivation 'hello'
-
-         at /home/nix-user/hello.nix:9:3:
-
-            8|
-            9|   src = fetchzip {
-             |   ^
-           10|     url = "https://ftp.gnu.org/gnu/hello/hello-2.12.1.tar.gz";
-
-       error: hash mismatch in file downloaded from 'https://ftp.gnu.org/gnu/hello/hello-2.12.1.tar.gz':
-         specified: sha256:0000000000000000000000000000000000000000000000000000
-         got:       sha256:0xw6cr5jgi1ir13q6apvrivwmmpr5j8vbymp0x6ll0kcv6366hnn
-       error: 1 dependencies of derivation '/nix/store/8l961ay0q0ydfsgby0ngz6nmkchjqd50-hello-2.12.1.drv' failed to build
+error: hash mismatch in fixed-output derivation '/nix/store/pd2kiyfa0c06giparlhd1k31bvllypbb-source.drv':
+         specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+            got:    sha256-1kJjhtlsAkpNB7f6tZEs+dbKd8z7KoNHyDHEJ0tmhnc=
+error: 1 dependencies of derivation '/nix/store/b4mjwlv73nmiqgkdabsdjc4zq9gnma1l-hello-2.12.1.drv' failed to build
 ```
 
 ### Finding the file hash
@@ -184,7 +173,7 @@ stdenv.mkDerivation {
 
   src = fetchzip {
     url = "https://ftp.gnu.org/gnu/hello/hello-2.12.1.tar.gz";
-    sha256 = "0xw6cr5jgi1ir13q6apvrivwmmpr5j8vbymp0x6ll0kcv6366hnn";
+    sha256 = "sha256-1kJjhtlsAkpNB7f6tZEs+dbKd8z7KoNHyDHEJ0tmhnc=";
   };
 }
 ```


### PR DESCRIPTION
* Replace nix-build output in tutorial for packaging existing software. Previous output does not match current output, and uses different hash formats. Output and hash has been updated.
* Update the port in CONTRIBUTING.md the local server runs at from 5500 to 8080 which is what it was when I ran with no changes.

Resolves issues raised in #1135 