### PR TITLE
Add hydra proxy header with well-known X-From

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -37,7 +37,5 @@
 
 /permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301
 /manual/nix /reference/nix-manual 200
-/manual/nix/unstable/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
-/manual/nix/development/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
 /tutorials/nixos/continuous-integration-github-actions /guides/recipes/continuous-integration-github-actions 301
 /guides/recipes/autoformatting /guides/faq#how-to-format-nix-language-code-automatically 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[[redirects]]
+from = "/manual/nix/unstable/*"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+status = 200
+force = true
+[redirects.headers]
+X-From = "nix.dev-Uogho3gi"
+
+[[redirects]]
+from = "/manual/nix/development/*"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+status = 200
+force = true
+[redirects.headers]
+X-From = "nix.dev-Uogho3gi"


### PR DESCRIPTION
This has now become required to bypass anubis on hydra.nixos.org.

Thanks, @adamcstephens, for preparing this.