### PR TITLE
Pass X-From header when reverse-proxying hydra

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -37,7 +37,5 @@
 
 /permalink/stub-ld /guides/faq#how-to-run-non-nix-executables 301
 /manual/nix /reference/nix-manual 200
-/manual/nix/unstable/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
-/manual/nix/development/* https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat 200
 /tutorials/nixos/continuous-integration-github-actions /guides/recipes/continuous-integration-github-actions 301
 /guides/recipes/autoformatting /guides/faq#how-to-format-nix-language-code-automatically 301

--- a/default.nix
+++ b/default.nix
@@ -79,6 +79,7 @@ let
           mkdir -p $out/manual/nix
           cp -R build/html/* $out/
           cp build/latex/nix-dev.pdf $out/
+          cp netlify.toml $out/
         '' + lib.optionalString withManuals ''
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList release releases.nixReleases)}
           ${lib.concatStringsSep "\n" (lib.mapAttrsToList mutableRedirect releases.mutableNixManualRedirects)}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+[[redirects]]
+from = "/manual/nix/unstable/*"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+status = 200
+force = true
+[redirects.headers]
+X-From = "nix.dev-Uogho3gi"
+
+[[redirects]]
+from = "/manual/nix/development/*"
+to = "https://hydra.nixos.org/job/nix/master/manual/latest/download/1/manual/:splat"
+status = 200
+force = true
+[redirects.headers]
+X-From = "nix.dev-Uogho3gi"


### PR DESCRIPTION
On the third try I now checked the build process, and we now copy the netlify.toml into the build result. No idea how that works for the _redirects file in the repo root.