### PR TITLE
Fix search container margin causing unintentional element overlap

### DIFF
--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -3,8 +3,8 @@
 }
 
 div.highlight-shell-session + div.highlight-none pre {
-  background-color: var(--pst-color-preformatted-text), 1 !important;
-  color: var(--pst-color-preformatted-background), 1 !important;
+  background-color: var(--pst-color-preformatted-text),1 !important;
+  color: var(--pst-color-preformatted-background),1 !important;
 }
 
 div.expression > div.highlight > pre::before {
@@ -35,9 +35,7 @@ div.highlight > pre::before {
   color: #fff;
   font-size: 0.8em;
   border-radius: 0 0.4em 0 0.4em;
-  transition:
-    opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1),
-    transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+  transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
 }
 
 div.highlight:hover > pre::before {

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -93,11 +93,6 @@ html[data-theme="dark"] .highlight .gd {
   vertical-align: middle;
 }
 
-.bd-search {
-  /* margin-top: -2rem; */
-  /* margin-bottom: -1rem; */
-}
-
 .navbar-nav li.toctree-l1 {
   margin-top: 1rem;
   margin-bottom: 0.5rem;

--- a/source/_static/css/custom.css
+++ b/source/_static/css/custom.css
@@ -3,8 +3,8 @@
 }
 
 div.highlight-shell-session + div.highlight-none pre {
-  background-color: var(--pst-color-preformatted-text),1 !important;
-  color: var(--pst-color-preformatted-background),1 !important;
+  background-color: var(--pst-color-preformatted-text), 1 !important;
+  color: var(--pst-color-preformatted-background), 1 !important;
 }
 
 div.expression > div.highlight > pre::before {
@@ -35,7 +35,9 @@ div.highlight > pre::before {
   color: #fff;
   font-size: 0.8em;
   border-radius: 0 0.4em 0 0.4em;
-  transition: opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1), transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
+  transition:
+    opacity 0.2s cubic-bezier(0.64, 0.09, 0.08, 1),
+    transform 0.2s cubic-bezier(0.64, 0.09, 0.08, 1);
 }
 
 div.highlight:hover > pre::before {
@@ -92,8 +94,8 @@ html[data-theme="dark"] .highlight .gd {
 }
 
 .bd-search {
-  margin-top: -2rem;
-  margin-bottom: -1rem;
+  /* margin-top: -2rem; */
+  /* margin-bottom: -1rem; */
 }
 
 .navbar-nav li.toctree-l1 {


### PR DESCRIPTION
Before ([URL](https://nix.dev/search.html?q=nix#n)):
![image](https://github.com/user-attachments/assets/c6ec8afe-f63e-4943-8f87-f47c0d3bbb12)

After (with proposed changes):
![image](https://github.com/user-attachments/assets/089b4959-6707-486f-bab1-44e7a5d006f7)

