### PR TITLE
Fix GitHub Navbar Button Redirecting to PDF

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -151,8 +151,6 @@ html_theme_options = {
     "repository_branch": "master",
     "path_to_docs": "source",
     "use_repository_button": True,
-    "use_issues_button": True,
-    "use_edit_page_button": True,
     "show_navbar_depth": 2,
 }
 


### PR DESCRIPTION
On [nix.dev](https://nix.dev), the GitHub repository button in the navbar was incorrectly pointing to the generated PDF instead of the repository. This issue was linked to enabling both `use_issues_button` and `use_edit_page_button` in the Sphinx Book Theme’s `html_theme_options`. I'm not entirely sure why disabling these options resolves the redirect, but after removal the button now links correctly to the repo.

This change removes those two options from `source/conf.py`, restoring the repo button’s default behavior (linking to https://github.com/NixOS/nix.dev).

## Changes
- Delete `use_issues_button`
- Delete `use_edit_page_button`

Both entries are removed from `html_theme_options` in `source/conf.py`.


