### PR TITLE
add more authors and editors to tutorials and guides

### DIFF
--- a/source/concepts/flakes.md
+++ b/source/concepts/flakes.md
@@ -1,6 +1,10 @@
 (flakes-definition)=
 # Flakes
 
+```{contributors}
+:authors: kiara
+```
+
 ## What are flakes?
 
 Flakes offer an entrypoint file `flake.nix` aimed at sharing Nix code.

--- a/source/contributors.yaml
+++ b/source/contributors.yaml
@@ -1,8 +1,26 @@
+djacu:
+  name: Daniel Baker
+domenkozar:
+  name: Domen Kožar
 fricklerhandwerk:
   name: Valentin Gagarin
+grahamc:
+  name: Graham Christensen
 infinisil:
   name: Silvan Mosberger
+kiara:
+  name: Kiara Grouwstra
+  github: KiaraGrouwstra
 mmesch:
   name: Matthias Meschede
 NobbZ:
   name: Norbert Melzer
+olafklingt:
+proofconstruction:
+  name: Alexander Groleau
+rapenne-s:
+  name: Solène Rapenne
+tfc:
+  name: Jacek Galowicz
+zmitchell:
+  name: Zach Mitchell

--- a/source/guides/best-practices.md
+++ b/source/guides/best-practices.md
@@ -1,5 +1,10 @@
 # Best practices
 
+```{contributors}
+:authors: domenkozar
+:editors: fricklerhandwerk, infinisil
+```
+
 ## URLs
 
 The Nix language syntax supports bare URLs, so one could write `https://example.com` instead of `"https://example.com"`

--- a/source/guides/recipes/continuous-integration-github-actions.md
+++ b/source/guides/recipes/continuous-integration-github-actions.md
@@ -9,6 +9,10 @@ myst:
 
 # Continuous integration with GitHub Actions
 
+```{contributors}
+:authors: domenkozar
+```
+
 Set up [GitHub Actions](https://github.com/features/actions) as your continuous integration (CI) workflow for commits and pull requests.
 
 Nix lets CI build and cache developer environments for every project on every branch using binary caches.

--- a/source/guides/recipes/post-build-hook.md
+++ b/source/guides/recipes/post-build-hook.md
@@ -1,6 +1,10 @@
 (post-build-hooks)=
 # Setting up post-build hooks
 
+```{contributors}
+:authors: grahamc
+```
+
 This guide shows how to use the Nix [`post-build-hook`](https://nix.dev/manual/nix/2.22/command-ref/conf-file#conf-post-build-hook) configuration option to automatically upload build results to an [S3-compatible binary cache](https://nix.dev/manual/nix/2.22/store/types/s3-binary-cache-store).
 
 ## Implementation caveats

--- a/source/tutorials/first-steps/ad-hoc-shell-environments.md
+++ b/source/tutorials/first-steps/ad-hoc-shell-environments.md
@@ -2,6 +2,11 @@
 
 # Ad hoc shell environments
 
+```{contributors}
+:authors: domenkozar
+:editors: fricklerhandwerk
+```
+
 In a Nix shell environment, you can immediately use any program packaged with Nix, without installing it permanently.
 
 You can also share the command invoking such a shell with others, and it will work on all Linux distributions, WSL, and macOS[^1].

--- a/source/tutorials/first-steps/declarative-shell.md
+++ b/source/tutorials/first-steps/declarative-shell.md
@@ -7,6 +7,10 @@ myst:
 (declarative-reproducible-envs)=
 # Declarative shell environments with `shell.nix`
 
+```{contributors}
+:authors: domenkozar, zmitchell
+:editors: fricklerhandwerk
+```
 ## Overview
 
 Declarative shell environments allow you to:

--- a/source/tutorials/first-steps/reproducible-scripts.md
+++ b/source/tutorials/first-steps/reproducible-scripts.md
@@ -2,6 +2,11 @@
 
 # Reproducible interpreted scripts
 
+```{contributors}
+:authors: rapenne-s
+:editors: fricklerhandwerk
+```
+
 In this tutorial, you will learn how to use Nix to create and run reproducible interpreted scripts, also known as [shebang] scripts.
 
 ## Requirements

--- a/source/tutorials/module-system/a-basic-module/index.md
+++ b/source/tutorials/module-system/a-basic-module/index.md
@@ -1,5 +1,10 @@
 # A basic module
 
+```{contributors}
+:authors: djacu
+:editors: fricklerhandwerk
+```
+
 What is a module?
 
 * A module is a function that takes an attribute set and returns an attribute set.

--- a/source/tutorials/module-system/deep-dive.md
+++ b/source/tutorials/module-system/deep-dive.md
@@ -3,6 +3,11 @@
 
 Or: *Wrapping the world in modules*
 
+```{contributors}
+:authors: infinisil
+:editors: fricklerhandwerk, proofconstruction
+```
+
 In this tutorial you will follow an extensive demonstration of how to wrap an existing API with Nix modules.
 
 ## Overview

--- a/source/tutorials/nixos/binary-cache-setup.md
+++ b/source/tutorials/nixos/binary-cache-setup.md
@@ -8,6 +8,11 @@ myst:
 (setup-http-binary-cache)=
 # Setting up an HTTP binary cache
 
+```{contributors}
+:authors: tfc
+:editors: fricklerhandwerk
+```
+
 A binary cache stores pre-built [Nix store objects](https://nix.dev/manual/nix/latest/store/store-object) and provides them to other machines over the network.
 Any machine with a Nix store can be a binary cache for other machines.
 

--- a/source/tutorials/nixos/building-and-running-docker-images.md
+++ b/source/tutorials/nixos/building-and-running-docker-images.md
@@ -8,6 +8,10 @@ myst:
 (nixos-docker-images)=
 # Building and running Docker images
 
+```{contributors}
+:authors: domenkozar
+```
+
 [Docker](https://www.docker.com/) is a set of tools and services used to build, manage and deploy containers.
 
 Many cloud platforms offer Docker-based container hosting.

--- a/source/tutorials/nixos/building-bootable-iso-image.md
+++ b/source/tutorials/nixos/building-bootable-iso-image.md
@@ -1,6 +1,10 @@
 (bootable-iso-image)=
 # Building a bootable ISO image
 
+```{contributors}
+:authors: domenkozar
+```
+
 :::{note}
 If you need to build images for a different platform, see [Cross compiling](https://github.com/nix-community/nixos-generators#user-content-cross-compiling).
 :::

--- a/source/tutorials/nixos/deploying-nixos-using-terraform.md
+++ b/source/tutorials/nixos/deploying-nixos-using-terraform.md
@@ -8,6 +8,9 @@ myst:
 (deploy-nixos-using-terraform)=
 # Deploying NixOS using Terraform
 
+```{contributors}
+:authors: domenkozar
+```
 This tutorial assumes you're [familiar with the basics of Terraform](https://www.terraform.io/intro/index.html).
 By the end, you will have provisioned an Amazon Web Services (AWS) instance with Terraform and used Nix to deploy incremental changes to NixOS running on the instance.
 

--- a/source/tutorials/nixos/distributed-builds-setup.md
+++ b/source/tutorials/nixos/distributed-builds-setup.md
@@ -8,6 +8,11 @@ myst:
 (distributed-build-setup-tutorial)=
 # Setting up distributed builds
 
+```{contributors}
+:authors: tfc
+:editors: fricklerhandwerk
+```
+
 Nix can speed up builds by spreading the work across multiple computers at once.
 
 ## Introduction

--- a/source/tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
+++ b/source/tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
@@ -8,6 +8,11 @@ myst:
 
 # Installing NixOS on a Raspberry Pi
 
+```{contributors}
+:authors: domenkozar
+:editors: proofconstruction
+```
+
 This tutorial assumes you have a [Raspberry Pi 4 Model B with 4GB RAM](https://www.raspberrypi.org/products/raspberry-pi-4-model-b/).
 
 Before starting this tutorial, make sure you have

--- a/source/tutorials/nixos/integration-testing-using-virtual-machines.md
+++ b/source/tutorials/nixos/integration-testing-using-virtual-machines.md
@@ -2,6 +2,11 @@
 
 # Integration testing with NixOS virtual machines
 
+```{contributors}
+:authors: olafklingt, domenkozar
+:editors: fricklerhandwerk
+```
+
 ## What will you learn?
 
 This tutorial introduces Nixpkgs functionality for testing NixOS configurations.

--- a/source/tutorials/nixos/nixos-configuration-on-vm.md
+++ b/source/tutorials/nixos/nixos-configuration-on-vm.md
@@ -2,6 +2,11 @@
 
 # NixOS virtual machines
 
+```{contributors}
+:authors: olafklingt, domenkozar
+:editors: fricklerhandwerk
+```
+
 One of the most important features of NixOS is the ability to configure the entire system declaratively, including packages to be installed, services to be run, as well as other settings and options.
 
 NixOS configurations can be used to test and use NixOS using a virtual machine, which is a lighter weight option compared to a full "bare metal" installation.

--- a/source/tutorials/nixos/provisioning-remote-machines.md
+++ b/source/tutorials/nixos/provisioning-remote-machines.md
@@ -8,6 +8,11 @@ myst:
 (provisioning-remote-machines-tutorial)=
 # Provisioning remote machines via SSH
 
+```{contributors}
+:authors: tfc
+:editors: fricklerhandwerk
+```
+
 It is possible to replace any Linux installation with a NixOS configuration on running systems using [`nixos-anywhere`] and [`disko`].
 
 [`nixos-anywhere`]: https://nix-community.github.io/nixos-anywhere/

--- a/source/tutorials/packaging-existing-software.md
+++ b/source/tutorials/packaging-existing-software.md
@@ -8,6 +8,11 @@ myst:
 (packaging-tutorial)=
 # Packaging existing software with Nix
 
+```{contributors}
+:authors: proofconstruction
+:editors: fricklerhandwerk
+```
+
 One of Nix's primary use-cases is in addressing common difficulties encountered with packaging software, such as specifying and obtaining dependencies.
 
 In the long term, Nix alleviates such problems.

--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -1,6 +1,10 @@
 (file-sets-tutorial)=
 # Working with local files
 
+```{contributors}
+:authors: infinisil
+```
+
 To build a local project in a Nix derivation, source files must be accessible to its [`builder` executable](https://nix.dev/manual/nix/stable/language/derivations#attr-builder).
 By default, the `builder` runs in an [isolated environment](https://nix.dev/manual/nix/stable/command-ref/conf-file.html#conf-sandbox) that only allows reading from the Nix store.
 The Nix language has built-in features to copy local files to the store and expose the resulting store paths.


### PR DESCRIPTION
Closes #543

Depends on #1260

This is done mostly from memory and cursory inspection of commit history.
It may still be incomplete or a bit inaccurate, but it should do its job as a first way-better-than-nothing approximation.