### PR TITLE
Fix pinned versions of EOL NixOS

### DIFF
--- a/source/tutorials/cross-compilation.md
+++ b/source/tutorials/cross-compilation.md
@@ -49,7 +49,7 @@ The build platform is determined automatically by Nix during the configure phase
 The host platform is best determined by running this command on the host platform:
 
 ```shell-session
-$ $(nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-23.11 -A gnu-config)/config.guess
+$ $(nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-26.05 -A gnu-config)/config.guess
 aarch64-unknown-linux-gnu
 ```
 
@@ -88,45 +88,63 @@ It is possible to explore them in `nix repl`:
 :::{note}
 [Starting with Nix 2.19](https://nix.dev/manual/nix/latest/release-notes/rl-2.19), `nix repl` requires the `-f` / `--file` flag:
 ```shell-session
-$ nix repl -f '<nixpkgs>' -I nixpkgs=channel:nixos-23.11
+$ nix repl -f '<nixpkgs>' -I nixpkgs=channel:nixos-26.05
 ```
 :::
 
 ```shell-session
-$ nix repl '<nixpkgs>' -I nixpkgs=channel:nixos-23.11
-Welcome to Nix 2.18.1. Type :? for help.
-
-Loading '<nixpkgs>'...
-Added 14200 variables.
+$ nix repl '<nixpkgs>' -I nixpkgs=channel:nixos-26.05
+Nix 2.34.8
+Type :? for help.
+Loading installable ''...
+Added 27226 variables.
 
 nix-repl> pkgsCross.<TAB>
-pkgsCross.aarch64-android             pkgsCross.musl-power
-pkgsCross.aarch64-android-prebuilt    pkgsCross.musl32
-pkgsCross.aarch64-darwin              pkgsCross.musl64
-pkgsCross.aarch64-embedded            pkgsCross.muslpi
-pkgsCross.aarch64-multiplatform       pkgsCross.or1k
-pkgsCross.aarch64-multiplatform-musl  pkgsCross.pogoplug4
+pkgsCross.aarch64-android             pkgsCross.mipsel-linux-gnu
+pkgsCross.aarch64-android-prebuilt    pkgsCross.mmix
+pkgsCross.aarch64-darwin              pkgsCross.msp430
+pkgsCross.aarch64-embedded            pkgsCross.musl-power
+pkgsCross.aarch64-freebsd             pkgsCross.musl32
+pkgsCross.aarch64-multiplatform       pkgsCross.musl64
+pkgsCross.aarch64-multiplatform-musl  pkgsCross.muslpi
+pkgsCross.aarch64-unknown-uefi        pkgsCross.or1k
+pkgsCross.aarch64-windows             pkgsCross.pogoplug4
 pkgsCross.aarch64be-embedded          pkgsCross.powernv
-pkgsCross.amd64-netbsd                pkgsCross.ppc-embedded
-pkgsCross.arm-embedded                pkgsCross.ppc64
-pkgsCross.armhf-embedded              pkgsCross.ppc64-musl
-pkgsCross.armv7a-android-prebuilt     pkgsCross.ppcle-embedded
-pkgsCross.armv7l-hf-multiplatform     pkgsCross.raspberryPi
-pkgsCross.avr                         pkgsCross.remarkable1
-pkgsCross.ben-nanonote                pkgsCross.remarkable2
-pkgsCross.fuloongminipc               pkgsCross.riscv32
-pkgsCross.ghcjs                       pkgsCross.riscv32-embedded
-pkgsCross.gnu32                       pkgsCross.riscv64
-pkgsCross.gnu64                       pkgsCross.riscv64-embedded
-pkgsCross.i686-embedded               pkgsCross.scaleway-c1
-pkgsCross.iphone32                    pkgsCross.sheevaplug
-pkgsCross.iphone32-simulator          pkgsCross.vc4
-pkgsCross.iphone64                    pkgsCross.wasi32
-pkgsCross.iphone64-simulator          pkgsCross.x86_64-embedded
-pkgsCross.mingw32                     pkgsCross.x86_64-netbsd
-pkgsCross.mingwW64                    pkgsCross.x86_64-netbsd-llvm
-pkgsCross.mmix                        pkgsCross.x86_64-unknown-redox
-pkgsCross.msp430
+pkgsCross.arc                         pkgsCross.ppc-embedded
+pkgsCross.arm-embedded                pkgsCross.ppc32
+pkgsCross.arm-embedded-nano           pkgsCross.ppc64
+pkgsCross.armhf-embedded              pkgsCross.ppc64-elfv1
+pkgsCross.armv7a-android-prebuilt     pkgsCross.ppc64-elfv2
+pkgsCross.armv7l-hf-multiplatform     pkgsCross.ppc64-musl
+pkgsCross.avr                         pkgsCross.ppcle-embedded
+pkgsCross.ben-nanonote                pkgsCross.raspberryPi
+pkgsCross.bluefield2                  pkgsCross.remarkable1
+pkgsCross.fuloongminipc               pkgsCross.remarkable2
+pkgsCross.ghcjs                       pkgsCross.riscv32
+pkgsCross.gnu32                       pkgsCross.riscv32-embedded
+pkgsCross.gnu64                       pkgsCross.riscv64
+pkgsCross.gnu64_simplekernel          pkgsCross.riscv64-embedded
+pkgsCross.i686-embedded               pkgsCross.riscv64-musl
+pkgsCross.iphone64                    pkgsCross.rx-embedded
+pkgsCross.iphone64-simulator          pkgsCross.s390
+pkgsCross.loongarch64-linux           pkgsCross.s390x
+pkgsCross.loongarch64-linux-embedded  pkgsCross.sh4
+pkgsCross.m68k                        pkgsCross.sheevaplug
+pkgsCross.microblaze-embedded         pkgsCross.ucrt64
+pkgsCross.mingw-msvcrt-i686           pkgsCross.ucrtAarch64
+pkgsCross.mingw-msvcrt-x86_64         pkgsCross.vc4
+pkgsCross.mingw-ucrt-aarch64          pkgsCross.wasi32
+pkgsCross.mingw-ucrt-x86_64           pkgsCross.wasm32-unknown-none
+pkgsCross.mingw-ucrt-x86_64-llvm      pkgsCross.x86_64-cygwin
+pkgsCross.mingw32                     pkgsCross.x86_64-darwin
+pkgsCross.mingwW64                    pkgsCross.x86_64-embedded
+pkgsCross.mips-embedded               pkgsCross.x86_64-freebsd
+pkgsCross.mips-linux-gnu              pkgsCross.x86_64-netbsd
+pkgsCross.mips64-embedded             pkgsCross.x86_64-netbsd-llvm
+pkgsCross.mips64-linux-gnuabi64       pkgsCross.x86_64-openbsd
+pkgsCross.mips64-linux-gnuabin32      pkgsCross.x86_64-unknown-uefi
+pkgsCross.mips64el-linux-gnuabi64     pkgsCross.x86_64-windows
+pkgsCross.mips64el-linux-gnuabin32
 ```
 
 These attribute names for cross compilation packages have been chosen somewhat freely over the course of time.
@@ -160,7 +178,7 @@ There are multiple equivalent ways to access packages targeted to the host platf
 
    ```nix
    let
-     nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-23.11";
+     nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-26.05";
      pkgs = import nixpkgs {};
    in
    pkgs.pkgsCross.aarch64-multiplatform.hello
@@ -171,7 +189,7 @@ There are multiple equivalent ways to access packages targeted to the host platf
 
    ```nix
    let
-     nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-23.11";
+     nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-26.05";
      pkgs = import nixpkgs { crossSystem = { config = "aarch64-unknown-linux-gnu"; }; };
    in
    pkgs.hello
@@ -180,7 +198,7 @@ There are multiple equivalent ways to access packages targeted to the host platf
    Equivalently, you can pass the host platform as an argument to `nix-build`:
 
    ```sh
-   $ nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-23.11 \
+   $ nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-26.05 \
      --arg crossSystem '{ config = "aarch64-unknown-linux-gnu"; }' \
      -A hello
    ```
@@ -190,10 +208,10 @@ There are multiple equivalent ways to access packages targeted to the host platf
 To cross compile a package like [hello](https://www.gnu.org/software/hello/), pick the platform attribute — `aarch64-multiplatform` in our case — and run:
 
 ```shell-session
-$ nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-23.11 \
+$ nix-build '<nixpkgs>' -I nixpkgs=channel:nixos-26.05 \
   -A pkgsCross.aarch64-multiplatform.hello
 ...
-/nix/store/1dx87l5rav8679lqigf9xxkb7wvh2m4k-hello-aarch64-unknown-linux-gnu-2.12.1
+/nix/store/lmgmr8b8czkxwfn3hpv0p5dv7jm4j4ks-hello-aarch64-unknown-linux-gnu-2.12.3
 ```
 
 :::{note}
@@ -210,7 +228,7 @@ Given we have a `cross-compile.nix`:
 
 ```nix
 let
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-23.11";
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-26.05";
   pkgs = import nixpkgs {};
 
   # Create a C program that prints Hello World
@@ -266,7 +284,7 @@ Given we have a `shell.nix`:
 
 ```nix
 let
-  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-23.11";
+  nixpkgs = fetchTarball "https://github.com/NixOS/nixpkgs/tarball/release-26.05";
   pkgs = (import nixpkgs {}).pkgsCross.aarch64-multiplatform;
 in
 
@@ -301,7 +319,7 @@ And confirm it's aarch64:
 
 ```shell-session
 $ nix-shell --run 'file hello' shell.nix
-hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, with debug_info, not stripped
+hello: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
 ```
 
 ## Next steps

--- a/source/tutorials/working-with-local-files.md
+++ b/source/tutorials/working-with-local-files.md
@@ -32,7 +32,7 @@ File sets can be created, composed, and manipulated with the various functions o
 You can explore and learn about the library with [`nix repl`](https://nix.dev/manual/nix/stable/command-ref/new-cli/nix3-repl):
 
 ```shell-session
-$ nix repl -f channel:nixos-23.11
+$ nix repl -f channel:nixos-26.05
 ...
 nix-repl> fs = lib.fileset
 ```
@@ -95,7 +95,7 @@ Create a new directory, enter it, and set up `npins` to pin the Nixpkgs dependen
 ```shell-session
 $ mkdir fileset
 $ cd fileset
-$ nix-shell -p npins --run "npins init --bare; npins add github nixos nixpkgs --branch nixos-23.11"
+$ nix-shell -p npins --run "npins init --bare; npins add github nixos nixpkgs --branch nixos-26.05"
 ```
 
 Then create a `default.nix` file with the following contents:


### PR DESCRIPTION
Noticed, nix.dev pins some NixOS versions which are EOL.

Started cleaning up with two commits, but there's a bit more.

- **tutorials: Update pinned NixOS version for cross-compilation**
- **tutorials: Update pinned NixOS versions for working-with-local-files**

Tested all changes so far, to know if the commands still builds. Won't be possible with every needed change I guess.

TODO:

```bash
$ grep -lr '21\.05\|21\.11\|22\.05\|22\.11\|23\.05\|23\.11\|24\.05\|24\.11\|25\.05\|25\.11'                                                                                                (fix-eol-nixos-pins)  
source/reference/pinning-nixpkgs.md
source/concepts/faq.md
source/_static/img/nix.svg
source/tutorials/nixos/nixos-configuration-on-vm.md
source/tutorials/nixos/installing-nixos-on-a-raspberry-pi.md
source/tutorials/nixos/integration-testing-using-virtual-machines.md
source/tutorials/nixos/provisioning-remote-machines.md
source/tutorials/packaging-existing-software.md
source/tutorials/first-steps/declarative-shell.md
source/tutorials/first-steps/towards-reproducibility-pinning-nixpkgs.md
source/tutorials/module-system/deep-dive.md
source/guides/recipes/direnv.md
source/guides/recipes/dependency-management.md
source/guides/recipes/python-environment.md
source/guides/recipes/sharing-dependencies.md
nix/sources.json
nix/releases.nix
```

Two questions, cc @hsjobeki:

1. Shall we remove EOL versions from npins (`nix/sources.json`)?
2. Can we find a generic way to not pin NixOS versions, thus keeping maintenance efforts low?
